### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azuremoops/terraform-azurerm-overlays-hubspoke/azurerm/)
 
-A terraform feature which includes modules needed to create an SCCA compliant Hub/Spoke Landing Zone based on the [Microsoft Azure Hub-Spoke Architecture](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke?tabs=cli) and can be used with the [Azure NoOps Accelerator](http://aka.ms/azurenoops).
+A terraform feature which includes modules needed to create an SCCA compliant Hub/Spoke Landing Zone based on the [Microsoft Azure Hub-Spoke Architecture](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke?tabs=cli).
 
 Overlay Feature includes:
 

--- a/_wip/multi-with-orchestration/versions.tf
+++ b/_wip/multi-with-orchestration/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/_wip/multi-with-orchestration/versions.tf
+++ b/_wip/multi-with-orchestration/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/_wip/multi-with-orchestration/versions.tf
+++ b/_wip/multi-with-orchestration/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@
 
 [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azuremoops/terraform-azurerm-overlays-hubspoke/azurerm/)
 
-A terraform feature which includes modules needed to create an SCCA compliant Hub/Spoke Landing Zone based on the [Microsoft Azure Hub-Spoke Architecture](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke?tabs=cli) and can be used with the [Azure NoOps Accelerator](http://aka.ms/azurenoops).
+A terraform feature which includes modules needed to create an SCCA compliant Hub/Spoke Landing Zone based on the [Microsoft Azure Hub-Spoke Architecture](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke?tabs=cli).
 
 Overlay Feature includes:
 

--- a/examples/multi-with-orchestration-w-wl-spoke/versions.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/versions.tf
@@ -8,13 +8,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.0.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/multi-with-orchestration-w-wl-spoke/versions.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
     azapi = {

--- a/examples/multi-with-orchestration-w-wl-spoke/versions.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
     azapi = {

--- a/examples/single-with-orchestration/README.md
+++ b/examples/single-with-orchestration/README.md
@@ -13,7 +13,7 @@ provider "azurerm" {
 }
 
 module "hub-spoke" {
-  source  = "azurenoops/overlays-hubspoke/azurerm"
+  source  = "POps-Rox/overlays-hubspoke/azurerm"
   version = "~> 1.0.0"
 
   #####################################

--- a/examples/single-with-orchestration/versions.tf
+++ b/examples/single-with-orchestration/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/single-with-orchestration/versions.tf
+++ b/examples/single-with-orchestration/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/single-with-orchestration/versions.tf
+++ b/examples/single-with-orchestration/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/operational-logging/README.md
+++ b/modules/operational-logging/README.md
@@ -112,8 +112,8 @@ module "mod_operational_logging" {
 | [azurerm_security_center_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_workspace) | resource |
 | [azurerm_storage_account.loganalytics_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_log_analytics_workspace.logws](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.logging_rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/modules/operational-logging/README.md
+++ b/modules/operational-logging/README.md
@@ -112,8 +112,8 @@ module "mod_operational_logging" {
 | [azurerm_security_center_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_workspace) | resource |
 | [azurerm_storage_account.loganalytics_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_log_analytics_workspace.logws](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.logging_rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/modules/operational-logging/README.md
+++ b/modules/operational-logging/README.md
@@ -9,7 +9,7 @@ This module deploys a logging rg to the operations spoke network using the [Micr
 # Licensed under the MIT License.
 
 module "mod_operational_logging" {
-  source  = "azurenoops/overlays-hubspoke/azurerm/modules/operational-logging"
+  source  = "POps-Rox/overlays-hubspoke/azurerm/modules/operational-logging"
   version = "~> 1.0.0"
 
   #####################################
@@ -76,14 +76,14 @@ module "mod_operational_logging" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 1.0.0 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
@@ -91,8 +91,8 @@ module "mod_operational_logging" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_logging_rg"></a> [mod\_logging\_rg](#module\_mod\_logging\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_logging_rg"></a> [mod\_logging\_rg](#module\_mod\_logging\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -112,8 +112,8 @@ module "mod_operational_logging" {
 | [azurerm_security_center_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_workspace) | resource |
 | [azurerm_storage_account.loganalytics_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [azurenoopsutils_resource_name.laws](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.logging_st](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_log_analytics_workspace.logws](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.logging_rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/modules/operational-logging/README.md
+++ b/modules/operational-logging/README.md
@@ -112,8 +112,8 @@ module "mod_operational_logging" {
 | [azurerm_security_center_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_workspace) | resource |
 | [azurerm_storage_account.loganalytics_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_log_analytics_workspace.logws](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.logging_rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |

--- a/modules/operational-logging/locals-naming.tf
+++ b/modules/operational-logging/locals-naming.tf
@@ -6,6 +6,6 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.azurenoopsutils_resource_name.logging_st.result)
-  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.azurenoopsutils_resource_name.laws.result)
+  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
+  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
 }

--- a/modules/operational-logging/locals-naming.tf
+++ b/modules/operational-logging/locals-naming.tf
@@ -6,6 +6,6 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
-  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
+  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.popsrox_resource_name.logging_st.result)
+  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.popsrox_resource_name.laws.result)
 }

--- a/modules/operational-logging/locals-naming.tf
+++ b/modules/operational-logging/locals-naming.tf
@@ -6,6 +6,6 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.popsrox_resource_name.logging_st.result)
-  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.popsrox_resource_name.laws.result)
+  ops_logging_sa_name  = coalesce(var.ops_logging_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
+  ops_logging_law_name = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
 }

--- a/modules/operational-logging/naming.tf
+++ b/modules/operational-logging/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_utils_resource_name" "logging_st" {
+data "popsrox_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -9,7 +9,7 @@ data "popsrox_utils_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_utils_resource_name" "laws" {
+data "popsrox_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/operational-logging/naming.tf
+++ b/modules/operational-logging/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "logging_st" {
+data "popsrox_utils_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -9,7 +9,7 @@ data "azurenoopsutils_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "azurenoopsutils_resource_name" "laws" {
+data "popsrox_utils_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/operational-logging/naming.tf
+++ b/modules/operational-logging/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_resource_name" "logging_st" {
+data "popsrox_utils_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -9,7 +9,7 @@ data "popsrox_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_resource_name" "laws" {
+data "popsrox_utils_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/operational-logging/versions.tf
+++ b/modules/operational-logging/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/operational-logging/versions.tf
+++ b/modules/operational-logging/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/modules/operational-logging/versions.tf
+++ b/modules/operational-logging/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/virtual-network-hub/README.md
+++ b/modules/virtual-network-hub/README.md
@@ -106,17 +106,17 @@ These types of resources are supported:
 | [azurerm_subnet_route_table_association.rtassoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_string.str](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [popsrox_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/virtual-network-hub/README.md
+++ b/modules/virtual-network-hub/README.md
@@ -30,14 +30,14 @@ These types of resources are supported:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
@@ -45,8 +45,8 @@ These types of resources are supported:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_hub_rg"></a> [mod\_hub\_rg](#module\_mod\_hub\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_hub_rg"></a> [mod\_hub\_rg](#module\_mod\_hub\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -106,17 +106,17 @@ These types of resources are supported:
 | [azurerm_subnet_route_table_association.rtassoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_string.str](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [azurenoopsutils_resource_name.bastion](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.bastion_pip](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.fw](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.fw_policy](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.nsg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.rt](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.snet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.st](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vnet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/virtual-network-hub/README.md
+++ b/modules/virtual-network-hub/README.md
@@ -106,17 +106,17 @@ These types of resources are supported:
 | [azurerm_subnet_route_table_association.rtassoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_string.str](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [popsrox_utils_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/virtual-network-hub/README.md
+++ b/modules/virtual-network-hub/README.md
@@ -106,17 +106,17 @@ These types of resources are supported:
 | [azurerm_subnet_route_table_association.rtassoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [random_string.str](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [popsrox_utils_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.bastion_pip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_client_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_mgt_pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.fw_policy](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/virtual-network-hub/locals-naming.tf
+++ b/modules/virtual-network-hub/locals-naming.tf
@@ -6,17 +6,17 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
-  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
-  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
-  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_utils_resource_name.fw.result}")
-  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_utils_resource_name.fw_policy.result}")
-  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_utils_resource_name.fw_client_pub_ip.result}")
-  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_utils_resource_name.fw_mgt_pub_ip.result}")
-  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
-  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_utils_resource_name.st.result)
+  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_resource_name.vnet.result)
+  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
+  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
+  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_resource_name.fw.result}")
+  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_resource_name.fw_policy.result}")
+  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_resource_name.fw_client_pub_ip.result}")
+  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_resource_name.fw_mgt_pub_ip.result}")
+  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
+  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_resource_name.st.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_utils_resource_name.bastion.result}")
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_utils_resource_name.bastion_pip.result}")
+  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_resource_name.bastion.result}")
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_resource_name.bastion_pip.result}")
 }

--- a/modules/virtual-network-hub/locals-naming.tf
+++ b/modules/virtual-network-hub/locals-naming.tf
@@ -6,17 +6,17 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_resource_name.vnet.result)
-  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
-  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
-  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_resource_name.fw.result}")
-  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_resource_name.fw_policy.result}")
-  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_resource_name.fw_client_pub_ip.result}")
-  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_resource_name.fw_mgt_pub_ip.result}")
-  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
-  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_resource_name.st.result)
+  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
+  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
+  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
+  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_utils_resource_name.fw.result}")
+  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_utils_resource_name.fw_policy.result}")
+  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_utils_resource_name.fw_client_pub_ip.result}")
+  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_utils_resource_name.fw_mgt_pub_ip.result}")
+  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
+  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_utils_resource_name.st.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_resource_name.bastion.result}")
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_resource_name.bastion_pip.result}")
+  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_utils_resource_name.bastion.result}")
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_utils_resource_name.bastion_pip.result}")
 }

--- a/modules/virtual-network-hub/locals-naming.tf
+++ b/modules/virtual-network-hub/locals-naming.tf
@@ -6,17 +6,17 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.azurenoopsutils_resource_name.vnet.result)
-  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.azurenoopsutils_resource_name.snet.result}")
-  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.azurenoopsutils_resource_name.nsg.result}")
-  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.azurenoopsutils_resource_name.fw.result}")
-  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.azurenoopsutils_resource_name.fw_policy.result}")
-  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.azurenoopsutils_resource_name.fw_client_pub_ip.result}")
-  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.azurenoopsutils_resource_name.fw_mgt_pub_ip.result}")
-  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.azurenoopsutils_resource_name.rt.result}")
-  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.azurenoopsutils_resource_name.st.result)
+  hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
+  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
+  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
+  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_utils_resource_name.fw.result}")
+  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_utils_resource_name.fw_policy.result}")
+  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_utils_resource_name.fw_client_pub_ip.result}")
+  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_utils_resource_name.fw_mgt_pub_ip.result}")
+  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
+  hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_utils_resource_name.st.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, "${data.azurenoopsutils_resource_name.bastion.result}")
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.azurenoopsutils_resource_name.bastion_pip.result}")
+  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_utils_resource_name.bastion.result}")
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_utils_resource_name.bastion_pip.result}")
 }

--- a/modules/virtual-network-hub/naming.tf
+++ b/modules/virtual-network-hub/naming.tf
@@ -6,7 +6,7 @@ resource "random_id" "id" {
   byte_length = 3
 }
 
-data "popsrox_utils_resource_name" "vnet" {
+data "popsrox_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -16,7 +16,7 @@ data "popsrox_utils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "fw" {
+data "popsrox_resource_name" "fw" {
   name          = var.workload_name
   resource_type = "azurerm_firewall"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -26,7 +26,7 @@ data "popsrox_utils_resource_name" "fw" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "fw_policy" {
+data "popsrox_resource_name" "fw_policy" {
   name          = var.workload_name
   resource_type = "azurerm_firewall_policy"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -36,7 +36,7 @@ data "popsrox_utils_resource_name" "fw_policy" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "snet" {
+data "popsrox_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -46,7 +46,7 @@ data "popsrox_utils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "fw_client_pub_ip" {
+data "popsrox_resource_name" "fw_client_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -56,7 +56,7 @@ data "popsrox_utils_resource_name" "fw_client_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "fw_mgt_pub_ip" {
+data "popsrox_resource_name" "fw_mgt_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -66,7 +66,7 @@ data "popsrox_utils_resource_name" "fw_mgt_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -76,7 +76,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "rt" {
+data "popsrox_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -86,7 +86,7 @@ data "popsrox_utils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "st" {
+data "popsrox_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -94,7 +94,7 @@ data "popsrox_utils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_utils_resource_name" "bastion" {
+data "popsrox_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -104,7 +104,7 @@ data "popsrox_utils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "bastion_pip" {
+data "popsrox_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-hub/naming.tf
+++ b/modules/virtual-network-hub/naming.tf
@@ -6,7 +6,7 @@ resource "random_id" "id" {
   byte_length = 3
 }
 
-data "popsrox_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -16,7 +16,7 @@ data "popsrox_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "fw" {
+data "popsrox_utils_resource_name" "fw" {
   name          = var.workload_name
   resource_type = "azurerm_firewall"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -26,7 +26,7 @@ data "popsrox_resource_name" "fw" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "fw_policy" {
+data "popsrox_utils_resource_name" "fw_policy" {
   name          = var.workload_name
   resource_type = "azurerm_firewall_policy"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -36,7 +36,7 @@ data "popsrox_resource_name" "fw_policy" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -46,7 +46,7 @@ data "popsrox_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "fw_client_pub_ip" {
+data "popsrox_utils_resource_name" "fw_client_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -56,7 +56,7 @@ data "popsrox_resource_name" "fw_client_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "fw_mgt_pub_ip" {
+data "popsrox_utils_resource_name" "fw_mgt_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -66,7 +66,7 @@ data "popsrox_resource_name" "fw_mgt_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -76,7 +76,7 @@ data "popsrox_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -86,7 +86,7 @@ data "popsrox_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -94,7 +94,7 @@ data "popsrox_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_resource_name" "bastion" {
+data "popsrox_utils_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -104,7 +104,7 @@ data "popsrox_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "bastion_pip" {
+data "popsrox_utils_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-hub/naming.tf
+++ b/modules/virtual-network-hub/naming.tf
@@ -6,7 +6,7 @@ resource "random_id" "id" {
   byte_length = 3
 }
 
-data "azurenoopsutils_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -16,7 +16,7 @@ data "azurenoopsutils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "fw" {
+data "popsrox_utils_resource_name" "fw" {
   name          = var.workload_name
   resource_type = "azurerm_firewall"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -26,7 +26,7 @@ data "azurenoopsutils_resource_name" "fw" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "fw_policy" {
+data "popsrox_utils_resource_name" "fw_policy" {
   name          = var.workload_name
   resource_type = "azurerm_firewall_policy"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -36,7 +36,7 @@ data "azurenoopsutils_resource_name" "fw_policy" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -46,7 +46,7 @@ data "azurenoopsutils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "fw_client_pub_ip" {
+data "popsrox_utils_resource_name" "fw_client_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -56,7 +56,7 @@ data "azurenoopsutils_resource_name" "fw_client_pub_ip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "fw_mgt_pub_ip" {
+data "popsrox_utils_resource_name" "fw_mgt_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -66,7 +66,7 @@ data "azurenoopsutils_resource_name" "fw_mgt_pub_ip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -76,7 +76,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -86,7 +86,7 @@ data "azurenoopsutils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -94,7 +94,7 @@ data "azurenoopsutils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "azurenoopsutils_resource_name" "bastion" {
+data "popsrox_utils_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -104,7 +104,7 @@ data "azurenoopsutils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "bastion_pip" {
+data "popsrox_utils_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-hub/versions.tf
+++ b/modules/virtual-network-hub/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/virtual-network-hub/versions.tf
+++ b/modules/virtual-network-hub/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/modules/virtual-network-hub/versions.tf
+++ b/modules/virtual-network-hub/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/virtual-network-spoke/README.md
+++ b/modules/virtual-network-spoke/README.md
@@ -135,11 +135,11 @@ module "mod_spoke_network" {
 | [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.hub_to_spoke](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.spoke_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.netwatch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/modules/virtual-network-spoke/README.md
+++ b/modules/virtual-network-spoke/README.md
@@ -135,11 +135,11 @@ module "mod_spoke_network" {
 | [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.hub_to_spoke](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.spoke_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.netwatch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/modules/virtual-network-spoke/README.md
+++ b/modules/virtual-network-spoke/README.md
@@ -135,11 +135,11 @@ module "mod_spoke_network" {
 | [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.hub_to_spoke](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.spoke_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.netwatch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/modules/virtual-network-spoke/README.md
+++ b/modules/virtual-network-spoke/README.md
@@ -14,7 +14,7 @@ This module deploys a spoke network using the [Microsoft recommended Hub-Spoke n
 # Licensed under the MIT License.
 
 module "mod_spoke_network" {  
-  source  = "azurenoops/overlays-hubspoke/azurerm/modules/virtual-network-spoke"
+  source  = "POps-Rox/overlays-hubspoke/azurerm/modules/virtual-network-spoke"
   version = "~> 1.0.0"
 
   #####################################
@@ -93,15 +93,15 @@ module "mod_spoke_network" {
 
 | Name | Version |
 |------|---------|
-| azurenoopsutils | ~> 1.0.4 |
+|  popsrox-utils | ~> 1.0.4 |
 | azurerm | ~> 3.22 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| mod\_azregions | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| mod\_spoke\_rg | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| mod\_azregions | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| mod\_spoke\_rg | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -135,11 +135,11 @@ module "mod_spoke_network" {
 | [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.hub_to_spoke](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.spoke_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [azurenoopsutils_resource_name.nsg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.rt](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.snet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.st](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vnet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.rt](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.netwatch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -6,10 +6,10 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
-  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
-  spoke_snet_pe_name = data.popsrox_utils_resource_name.snet.result
-  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
-  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
-  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_utils_resource_name.st.result)
+  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
+  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
+  spoke_snet_pe_name = data.popsrox_resource_name.snet.result
+  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
+  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
+  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_resource_name.st.result)
 }

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -6,10 +6,10 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.azurenoopsutils_resource_name.vnet.result)
-  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.azurenoopsutils_resource_name.snet.result}")
-  spoke_snet_pe_name = data.azurenoopsutils_resource_name.snet.result
-  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.azurenoopsutils_resource_name.nsg.result}")
-  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.azurenoopsutils_resource_name.rt.result}")
-  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.azurenoopsutils_resource_name.st.result)
+  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
+  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
+  spoke_snet_pe_name = data.popsrox_utils_resource_name.snet.result
+  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
+  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
+  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_utils_resource_name.st.result)
 }

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -6,10 +6,10 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
-  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
-  spoke_snet_pe_name = data.popsrox_resource_name.snet.result
-  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
-  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
-  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_resource_name.st.result)
+  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
+  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_utils_resource_name.snet.result}")
+  spoke_snet_pe_name = data.popsrox_utils_resource_name.snet.result
+  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_utils_resource_name.nsg.result}")
+  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_utils_resource_name.rt.result}")
+  spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_utils_resource_name.st.result)
 }

--- a/modules/virtual-network-spoke/naming.tf
+++ b/modules/virtual-network-spoke/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -11,7 +11,7 @@ data "azurenoopsutils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -21,7 +21,7 @@ data "azurenoopsutils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -31,7 +31,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -41,7 +41,7 @@ data "azurenoopsutils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-spoke/naming.tf
+++ b/modules/virtual-network-spoke/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_utils_resource_name" "vnet" {
+data "popsrox_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -11,7 +11,7 @@ data "popsrox_utils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "snet" {
+data "popsrox_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -21,7 +21,7 @@ data "popsrox_utils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -31,7 +31,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "rt" {
+data "popsrox_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -41,7 +41,7 @@ data "popsrox_utils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "st" {
+data "popsrox_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-spoke/naming.tf
+++ b/modules/virtual-network-spoke/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -11,7 +11,7 @@ data "popsrox_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -21,7 +21,7 @@ data "popsrox_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -31,7 +31,7 @@ data "popsrox_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -41,7 +41,7 @@ data "popsrox_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/modules/virtual-network-spoke/versions.tf
+++ b/modules/virtual-network-spoke/versions.tf
@@ -10,7 +10,7 @@ terraform {
       configuration_aliases = [azurerm.hub_network]
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/modules/virtual-network-spoke/versions.tf
+++ b/modules/virtual-network-spoke/versions.tf
@@ -9,9 +9,9 @@ terraform {
       version               = "~> 3.22"
       configuration_aliases = [azurerm.hub_network]
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/modules/virtual-network-spoke/versions.tf
+++ b/modules/virtual-network-spoke/versions.tf
@@ -9,8 +9,8 @@ terraform {
       version               = "~> 3.22"
       configuration_aliases = [azurerm.hub_network]
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/tests/fixtures/versions.tf
+++ b/tests/fixtures/versions.tf
@@ -8,8 +8,8 @@
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/tests/fixtures/versions.tf
+++ b/tests/fixtures/versions.tf
@@ -9,7 +9,7 @@
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/tests/fixtures/versions.tf
+++ b/tests/fixtures/versions.tf
@@ -8,9 +8,9 @@
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 } */

--- a/versions.tf
+++ b/versions.tf
@@ -8,13 +8,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.0.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
     azapi = {

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
     azapi = {


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` Terraform provider references with `POps-Rox/popsrox-utils` across the root module, all sub-modules, examples, WIP, and test fixtures. Also remove the `http://aka.ms/azurenoops` link from user-facing docs (Option A — remove).

## Changes
- `versions.tf` (root + 6 sub-paths): renamed provider key `azurenoopsutils` → `popsrox-utils`, updated source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `modules/virtual-network-hub/naming.tf`: 11 data sources `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `modules/virtual-network-hub/locals-naming.tf`: 11 data source refs updated
- `modules/virtual-network-spoke/naming.tf`: 5 data sources updated
- `modules/virtual-network-spoke/locals-naming.tf`: 6 data source refs updated
- `modules/operational-logging/naming.tf`: 2 data sources updated
- `modules/operational-logging/locals-naming.tf`: 2 data source refs updated
- `README.md`, `docs/index.md`: removed `http://aka.ms/azurenoops` link (Option A)
- `examples/single-with-orchestration/README.md`: module source `azurenoops/` → `POps-Rox/`
- All sub-module `README.md` files: provider/data-source/org name refs updated

## Testing
- `terraform fmt -recursive` passed with no changes
- `grep -r azurenoops` returns zero matches across all `.tf` and `.md` files

Closes #4
Closes #5