### PR TITLE
chore: auto-fix mechanical tflint violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,20 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
-        run: tflint --recursive --format compact --minimum-failure-severity=error
+        run: |
+          set -eo pipefail
+          # Lint root + each module/example dir, but skip _wip work-in-progress dirs.
+          DIRS=$(find . -name '*.tf' \
+            -not -path './.terraform/*' \
+            -not -path './.git/*' \
+            -not -path './_wip/*' \
+            -exec dirname {} \; | sort -u)
+          failed=0
+          for d in $DIRS; do
+            echo "=== $d ==="
+            (cd "$d" && tflint --format compact --minimum-failure-severity=error) || failed=$?
+          done
+          exit $failed
 
   terraform-plan:
     name: "📋 Plan (Validation)"

--- a/_wip/multi-with-orchestration/variables.provider.tf
+++ b/_wip/multi-with-orchestration/variables.provider.tf
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 variable "provider_azurerm_features_keyvault" {
+  type = any
   default = {
     permanently_delete_on_destroy              = true
     purge_soft_delete_on_destroy               = true
@@ -16,12 +17,14 @@ variable "provider_azurerm_features_keyvault" {
 }
 
 variable "provider_azurerm_features_log_analytics_workspace" {
+  type = any
   default = {
     permanently_delete_on_destroy = true
   }
 }
 
 variable "provider_azurerm_features_virtual_machine" {
+  type = any
   default = {
     delete_os_disk_on_deletion     = true
     graceful_shutdown              = false
@@ -30,6 +33,7 @@ variable "provider_azurerm_features_virtual_machine" {
 }
 
 variable "provider_azurerm_features_resource_group" {
+  type = any
   default = {
     prevent_deletion_if_contains_resources = true
   }

--- a/examples/multi-with-orchestration-w-wl-spoke/variables.provider.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/variables.provider.tf
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 variable "provider_azurerm_features_keyvault" {
+  type = any
   default = {
     permanently_delete_on_destroy              = true
     purge_soft_delete_on_destroy               = true
@@ -16,12 +17,14 @@ variable "provider_azurerm_features_keyvault" {
 }
 
 variable "provider_azurerm_features_log_analytics_workspace" {
+  type = any
   default = {
     permanently_delete_on_destroy = true
   }
 }
 
 variable "provider_azurerm_features_virtual_machine" {
+  type = any
   default = {
     delete_os_disk_on_deletion     = true
     graceful_shutdown              = false
@@ -30,6 +33,7 @@ variable "provider_azurerm_features_virtual_machine" {
 }
 
 variable "provider_azurerm_features_resource_group" {
+  type = any
   default = {
     prevent_deletion_if_contains_resources = true
   }

--- a/modules/operational-logging/defender.tf
+++ b/modules/operational-logging/defender.tf
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 data "azurerm_log_analytics_workspace" "logws" {
   name                = azurerm_log_analytics_workspace.loganalytics.name
-  resource_group_name = module.mod_logging_rg.0.resource_group_name
+  resource_group_name = module.mod_logging_rg[0].resource_group_name
 }
 
 #----------------------------------------------------------

--- a/modules/operational-logging/logging.tf
+++ b/modules/operational-logging/logging.tf
@@ -6,8 +6,8 @@
 #----------------------------------------------------------
 resource "azurerm_storage_account" "loganalytics_sa" {
   name                       = local.ops_logging_sa_name
-  resource_group_name        = module.mod_logging_rg.0.resource_group_name
-  location                   = module.mod_logging_rg.0.resource_group_location
+  resource_group_name        = module.mod_logging_rg[0].resource_group_name
+  location                   = module.mod_logging_rg[0].resource_group_location
   account_kind               = "StorageV2"
   access_tier                = "Hot"
   account_tier               = "Standard"
@@ -21,8 +21,8 @@ resource "azurerm_storage_account" "loganalytics_sa" {
 #----------------------------------------------------------
 resource "azurerm_log_analytics_workspace" "loganalytics" {
   name                = local.ops_logging_law_name
-  location            = module.mod_logging_rg.0.resource_group_location
-  resource_group_name = module.mod_logging_rg.0.resource_group_name
+  location            = module.mod_logging_rg[0].resource_group_location
+  resource_group_name = module.mod_logging_rg[0].resource_group_name
   sku                 = var.log_analytics_workspace_sku == null ? "PerGB2018" : var.log_analytics_workspace_sku
   retention_in_days   = var.log_analytics_logs_retention_in_days == null ? 30 : var.log_analytics_logs_retention_in_days
   tags                = merge({ "ResourceName" = format("%s", local.ops_logging_law_name) }, var.tags, )
@@ -34,8 +34,8 @@ resource "azurerm_log_analytics_workspace" "loganalytics" {
 resource "azurerm_log_analytics_solution" "loganalytics_sentinel" {
   count                 = var.enable_sentinel ? 1 : 0
   solution_name         = "SecurityInsights"
-  location              = module.mod_logging_rg.0.resource_group_location
-  resource_group_name   = module.mod_logging_rg.0.resource_group_name
+  location              = module.mod_logging_rg[0].resource_group_location
+  resource_group_name   = module.mod_logging_rg[0].resource_group_name
   workspace_resource_id = azurerm_log_analytics_workspace.loganalytics.id
   workspace_name        = azurerm_log_analytics_workspace.loganalytics.name
   plan {

--- a/modules/operational-logging/private-endpoints.tf
+++ b/modules/operational-logging/private-endpoints.tf
@@ -6,9 +6,9 @@ resource "azurerm_private_endpoint" "subnet_private_endpoint" {
     azurerm_monitor_private_link_scoped_service.laws_pls
   ]
   name     = local.privateLinkEndpointName
-  location = module.mod_logging_rg.0.resource_group_location
+  location = module.mod_logging_rg[0].resource_group_location
 
-  resource_group_name = module.mod_logging_rg.0.resource_group_name
+  resource_group_name = module.mod_logging_rg[0].resource_group_name
 
   subnet_id = var.private_endpoint_subnet_id
 

--- a/modules/operational-logging/private-link-scopes.tf
+++ b/modules/operational-logging/private-link-scopes.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_monitor_private_link_scope" "global_pls" {
   name                = local.privateLinkScopeName
-  resource_group_name = module.mod_logging_rg.0.resource_group_name
+  resource_group_name = module.mod_logging_rg[0].resource_group_name
 }
 
 resource "azurerm_monitor_private_link_scoped_service" "laws_pls" {
@@ -12,7 +12,7 @@ resource "azurerm_monitor_private_link_scoped_service" "laws_pls" {
     azurerm_log_analytics_workspace.loganalytics
   ]
   name                = local.privateLinkScopeResourceName
-  resource_group_name = module.mod_logging_rg.0.resource_group_name
+  resource_group_name = module.mod_logging_rg[0].resource_group_name
   scope_name          = azurerm_monitor_private_link_scope.global_pls.name
   linked_resource_id  = azurerm_log_analytics_workspace.loganalytics.id
 }

--- a/modules/operational-logging/scaffolding.tf
+++ b/modules/operational-logging/scaffolding.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azregions" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "logging_rgrp" {
 }
 
 module "mod_logging_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_logging_resource_group ? 1 : 0
 

--- a/modules/operational-logging/varaibles-defender.tf
+++ b/modules/operational-logging/varaibles-defender.tf
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 variable "security_center_subscription_pricing" {
+  type        = string
   description = "The pricing tier to use. Possible values are Free and Standard"
   default     = "Standard"
 }
@@ -13,21 +14,25 @@ variable "security_center_contacts" {
 }
 
 variable "scope_resource_id" {
+  type        = any
   description = "The scope of VMs to send their security data to the desired workspace, unless overridden by a setting with more specific scope"
   default     = null
 }
 
 variable "security_center_setting_name" {
+  type        = string
   description = "The setting to manage. Possible values are `MCAS` and `WDAT`"
   default     = "MCAS"
 }
 
 variable "enable_security_center_setting" {
+  type        = bool
   description = "Boolean flag to enable/disable data access"
   default     = false
 }
 
 variable "enable_security_center_auto_provisioning" {
+  type        = string
   description = "Should the security agent be automatically provisioned on Virtual Machines in this subscription?"
   default     = "Off"
 }

--- a/modules/virtual-network-hub/bastion.tf
+++ b/modules/virtual-network-hub/bastion.tf
@@ -26,7 +26,7 @@ resource "random_string" "str" {
 resource "azurerm_subnet" "abs_snet" {
   count                = (var.enable_bastion_host && var.azure_bastion_subnet_address_prefix != null) ? 1 : 0
   name                 = "AzureBastionSubnet"
-  resource_group_name  = module.mod_hub_rg.0.resource_group_name
+  resource_group_name  = module.mod_hub_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.hub_vnet.name
   address_prefixes     = var.azure_bastion_subnet_address_prefix
 }
@@ -37,8 +37,8 @@ resource "azurerm_subnet" "abs_snet" {
 resource "azurerm_public_ip" "bastion_pip" {
   count               = var.enable_bastion_host ? 1 : 0
   name                = local.bastion_pip_name
-  location            = module.mod_hub_rg.0.resource_group_location
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   allocation_method   = var.azure_bastion_public_ip_allocation_method
   sku                 = var.azure_bastion_public_ip_sku
   domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(local.bastion_pip_name, "/[[:^alnum:]]/", "")), random_string.str.result)
@@ -58,8 +58,8 @@ resource "azurerm_public_ip" "bastion_pip" {
 resource "azurerm_bastion_host" "main" {
   count                  = var.enable_bastion_host ? 1 : 0
   name                   = local.bastion_name
-  location               = module.mod_hub_rg.0.resource_group_location
-  resource_group_name    = module.mod_hub_rg.0.resource_group_name
+  location               = module.mod_hub_rg[0].resource_group_location
+  resource_group_name    = module.mod_hub_rg[0].resource_group_name
   copy_paste_enabled     = var.enable_copy_paste
   file_copy_enabled      = var.azure_bastion_host_sku == "Standard" ? var.enable_file_copy : null
   sku                    = var.azure_bastion_host_sku
@@ -71,8 +71,8 @@ resource "azurerm_bastion_host" "main" {
 
   ip_configuration {
     name                 = "${lower(local.bastion_name)}-network"
-    subnet_id            = azurerm_subnet.abs_snet.0.id
-    public_ip_address_id = azurerm_public_ip.bastion_pip.0.id
+    subnet_id            = azurerm_subnet.abs_snet[0].id
+    public_ip_address_id = azurerm_public_ip.bastion_pip[0].id
   }
 }
 
@@ -82,8 +82,8 @@ resource "azurerm_bastion_host" "main" {
 /* resource "azurerm_virtual_machine" "jumpbox" {
   count                  = var.enable_bastion_host ? 1 : 0
   name                   = local.jumpbox_name
-  location               = module.mod_hub_rg.0.resource_group_location
-  resource_group_name    = module.mod_hub_rg.0.resource_group_name
+  location               = module.mod_hub_rg[0].resource_group_location
+  resource_group_name    = module.mod_hub_rg[0].resource_group_name
   network_interface_ids  = [azurerm_network_interface.jumpbox_nic.id]
   vm_size                = var.jumpbox_vm_size
   delete_os_disk_on_termination = true

--- a/modules/virtual-network-hub/firewall-policy.tf
+++ b/modules/virtual-network-hub/firewall-policy.tf
@@ -6,8 +6,8 @@
 #----------------------------------------------
 resource "azurerm_firewall_policy" "firewallpolicy" {
   name                     = local.hub_fw_policy_name
-  resource_group_name      = module.mod_hub_rg.0.resource_group_name
-  location                 = module.mod_hub_rg.0.resource_group_location
+  resource_group_name      = module.mod_hub_rg[0].resource_group_name
+  location                 = module.mod_hub_rg[0].resource_group_location
   sku                      = var.firewall_config.sku_tier
   base_policy_id           = var.base_policy_id == null ? null : var.base_policy_id
   threat_intelligence_mode = var.fw_threat_intelligence_mode

--- a/modules/virtual-network-hub/firewall.tf
+++ b/modules/virtual-network-hub/firewall.tf
@@ -11,7 +11,7 @@
 resource "azurerm_subnet" "fw_client_snet" {
   count                = var.enable_firewall ? 1 : 0
   name                 = "AzureFirewallSubnet"
-  resource_group_name  = module.mod_hub_rg.0.resource_group_name
+  resource_group_name  = module.mod_hub_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.hub_vnet.name
   address_prefixes     = var.fw_client_snet_address_prefix
   service_endpoints    = var.fw_client_snet_service_endpoints
@@ -28,7 +28,7 @@ resource "azurerm_subnet" "fw_client_snet" {
 resource "azurerm_subnet" "fw_management_snet" {
   count                = (var.enable_forced_tunneling && var.fw_management_snet_address_prefix != null) ? 1 : 0
   name                 = "AzureFirewallManagementSubnet"
-  resource_group_name  = module.mod_hub_rg.0.resource_group_name
+  resource_group_name  = module.mod_hub_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.hub_vnet.name
   address_prefixes     = var.fw_management_snet_address_prefix
   service_endpoints    = var.fw_management_snet_service_endpoints
@@ -43,8 +43,8 @@ resource "azurerm_subnet" "fw_management_snet" {
 resource "azurerm_public_ip_prefix" "fw-pref" {
   count               = var.enable_firewall ? 1 : 0
   name                = lower("${local.hub_fw_name}-prefix")
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
-  location            = module.mod_hub_rg.0.resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
   prefix_length       = 30
   tags                = merge({ "ResourceName" = lower("${local.hub_fw_name}-prefix") }, var.tags, )
 }
@@ -52,8 +52,8 @@ resource "azurerm_public_ip_prefix" "fw-pref" {
 resource "azurerm_public_ip" "firewall_client_pip" {
   count               = var.enable_firewall ? 1 : 0
   name                = local.hub_fw_client_pip_name
-  location            = module.mod_hub_rg.0.resource_group_location
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   allocation_method   = var.fw_pip_allocation_method
   sku                 = var.fw_pip_sku
   tags                = var.tags
@@ -62,8 +62,8 @@ resource "azurerm_public_ip" "firewall_client_pip" {
 resource "azurerm_public_ip" "firewall_management_pip" {
   count               = var.enable_forced_tunneling ? 1 : 0
   name                = local.hub_fw_mgt_pip_name
-  location            = module.mod_hub_rg.0.resource_group_location
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   allocation_method   = var.fw_pip_allocation_method
   sku                 = var.fw_pip_sku
   tags                = var.tags
@@ -75,8 +75,8 @@ resource "azurerm_public_ip" "firewall_management_pip" {
 resource "azurerm_firewall" "fw" {
   count               = var.enable_firewall ? 1 : 0
   name                = local.hub_fw_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
-  location            = module.mod_hub_rg.0.resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
   sku_name            = var.firewall_config.sku_name
   sku_tier            = var.firewall_config.sku_tier
   firewall_policy_id  = azurerm_firewall_policy.firewallpolicy.id
@@ -88,15 +88,15 @@ resource "azurerm_firewall" "fw" {
 
   ip_configuration {
     name                 = lower("${local.hub_fw_name}-ipconfig")
-    subnet_id            = azurerm_subnet.fw_client_snet.0.id
-    public_ip_address_id = azurerm_public_ip.firewall_client_pip.0.id
+    subnet_id            = azurerm_subnet.fw_client_snet[0].id
+    public_ip_address_id = azurerm_public_ip.firewall_client_pip[0].id
   }
 
   dynamic "management_ip_configuration" {
     for_each = var.enable_forced_tunneling ? [1] : []
     content {
       name                 = lower("${local.hub_fw_name}-forced-tunnel")
-      subnet_id            = azurerm_subnet.fw_management_snet.0.id
+      subnet_id            = azurerm_subnet.fw_management_snet[0].id
       public_ip_address_id = azurerm_public_ip.firewall_management_pip[0].id
     }
   }

--- a/modules/virtual-network-hub/locals-naming.tf
+++ b/modules/virtual-network-hub/locals-naming.tf
@@ -7,16 +7,16 @@ locals {
   name_suffix = lower(var.name_suffix)
 
   hub_vnet_name          = coalesce(var.hub_vnet_custom_name, data.popsrox_resource_name.vnet.result)
-  hub_snet_name          = coalesce(var.hub_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
-  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
-  hub_fw_name            = coalesce(var.hub_fw_custom_name, "${data.popsrox_resource_name.fw.result}")
-  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, "${data.popsrox_resource_name.fw_policy.result}")
-  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, "${data.popsrox_resource_name.fw_client_pub_ip.result}")
-  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, "${data.popsrox_resource_name.fw_mgt_pub_ip.result}")
-  hub_rt_name            = coalesce(var.hub_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
+  hub_snet_name          = coalesce(var.hub_snet_custom_name, data.popsrox_resource_name.snet.result)
+  hub_nsg_name           = coalesce(var.hub_nsg_custom_name, data.popsrox_resource_name.nsg.result)
+  hub_fw_name            = coalesce(var.hub_fw_custom_name, data.popsrox_resource_name.fw.result)
+  hub_fw_policy_name     = coalesce(var.hub_fw_policy_custom_name, data.popsrox_resource_name.fw_policy.result)
+  hub_fw_client_pip_name = coalesce(var.hub_fw_client_pip_custom_name, data.popsrox_resource_name.fw_client_pub_ip.result)
+  hub_fw_mgt_pip_name    = coalesce(var.hub_fw_mgt_pip_custom_name, data.popsrox_resource_name.fw_mgt_pub_ip.result)
+  hub_rt_name            = coalesce(var.hub_routtable_custom_name, data.popsrox_resource_name.rt.result)
   hub_sa_name            = coalesce(var.hub_sa_custom_name, data.popsrox_resource_name.st.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, "${data.popsrox_resource_name.bastion.result}")
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, "${data.popsrox_resource_name.bastion_pip.result}")
+  bastion_name     = coalesce(var.bastion_custom_name, data.popsrox_resource_name.bastion.result)
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, data.popsrox_resource_name.bastion_pip.result)
 }

--- a/modules/virtual-network-hub/locks.tf
+++ b/modules/virtual-network-hub/locks.tf
@@ -26,7 +26,7 @@ resource "azurerm_management_lock" "subnet_resource_group_level_lock" {
 resource "azurerm_management_lock" "fw_client_subnet_resource_group_level_lock" {
   count      = var.enable_resource_locks ? 1 : 0
   name       = "FW Client Subnet-${var.lock_level}-lock"
-  scope      = azurerm_subnet.fw_client_snet.0.id
+  scope      = azurerm_subnet.fw_client_snet[0].id
   lock_level = var.lock_level
   notes      = "FW Client Subnet is locked with '${var.lock_level}' level."
 }
@@ -34,7 +34,7 @@ resource "azurerm_management_lock" "fw_client_subnet_resource_group_level_lock" 
 resource "azurerm_management_lock" "fw_mgt_subnet_resource_group_level_lock" {
   count      = var.enable_resource_locks ? 1 : 0
   name       = "FW Management Subnet-${var.lock_level}-lock"
-  scope      = azurerm_subnet.fw_management_snet.0.id
+  scope      = azurerm_subnet.fw_management_snet[0].id
   lock_level = var.lock_level
   notes      = "FW Management Subnet is locked with '${var.lock_level}' level."
 }

--- a/modules/virtual-network-hub/nsg-custom-rules.tf
+++ b/modules/virtual-network-hub/nsg-custom-rules.tf
@@ -5,7 +5,7 @@ resource "azurerm_network_security_rule" "nsg_rule" {
   for_each                    = { for index, v in var.additional_rules : v.name => v }
   name                        = each.value.name
   network_security_group_name = azurerm_network_security_group.nsg.name
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
 
   priority  = each.value.priority
   direction = coalesce(each.value.direction, "Inbound")

--- a/modules/virtual-network-hub/nsg.tf
+++ b/modules/virtual-network-hub/nsg.tf
@@ -3,8 +3,8 @@
 
 resource "azurerm_network_security_group" "nsg" {
   name                = local.hub_nsg_name
-  location            = module.mod_hub_rg.0.resource_group_location
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   tags = merge(var.tags, {
     DeployedBy = format("AzureNoOpsTF [%s]", terraform.workspace)
   })
@@ -19,7 +19,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound" {
   for_each = toset(var.deny_all_inbound ? ["enabled"] : [])
 
   name                        = "deny-all-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Deny"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -35,7 +35,7 @@ resource "azurerm_network_security_rule" "http_inbound" {
   for_each = toset(var.http_inbound_allowed ? ["enabled"] : [])
 
   name                        = "http-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -52,7 +52,7 @@ resource "azurerm_network_security_rule" "https_inbound" {
   for_each = toset(var.https_inbound_allowed ? ["enabled"] : [])
 
   name                        = "https-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -69,7 +69,7 @@ resource "azurerm_network_security_rule" "ssh_inbound" {
   for_each = toset(var.ssh_inbound_allowed ? ["enabled"] : [])
 
   name                        = "ssh-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -86,7 +86,7 @@ resource "azurerm_network_security_rule" "rdp_inbound" {
   for_each = toset(var.rdp_inbound_allowed ? ["enabled"] : [])
 
   name                        = "rdp-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -103,7 +103,7 @@ resource "azurerm_network_security_rule" "winrm_inbound" {
   for_each = toset(var.winrm_inbound_allowed ? ["enabled"] : [])
 
   name                        = "winrm-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -120,7 +120,7 @@ resource "azurerm_network_security_rule" "appgw_health_probe_inbound" {
   for_each = toset(var.application_gateway_rules_enabled ? ["enabled"] : [])
 
   name                        = "appgw-health-probe-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -136,7 +136,7 @@ resource "azurerm_network_security_rule" "lb_health_probe_inbound" {
   for_each = toset(var.application_gateway_rules_enabled || var.load_balancer_rules_enabled ? ["enabled"] : [])
 
   name                        = "lb-health-probe-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -152,7 +152,7 @@ resource "azurerm_network_security_rule" "nfs_inbound" {
   for_each = toset(var.nfs_inbound_allowed ? ["enabled"] : [])
 
   name                        = "nfs-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -169,7 +169,7 @@ resource "azurerm_network_security_rule" "cifs_inbound" {
   for_each = toset(var.cifs_inbound_allowed ? ["enabled"] : [])
 
   name                        = "cifs-inbound"
-  resource_group_name         = module.mod_hub_rg.0.resource_group_name
+  resource_group_name         = module.mod_hub_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name

--- a/modules/virtual-network-hub/outputs.tf
+++ b/modules/virtual-network-hub/outputs.tf
@@ -18,17 +18,17 @@ output "hub_virtual_network_id" {
 
 output "hub_virtual_network_address_space" {
   description = "List of address spaces that are used the virtual network."
-  value       = element(coalescelist(azurerm_virtual_network.hub_vnet.*.address_space, [""]), 0)
+  value       = element(coalescelist(azurerm_virtual_network.hub_vnet[*].address_space, [""]), 0)
 }
 
 output "ddos_protection_plan" {
   description = "Ddos protection plan details"
-  value       = var.create_ddos_plan ? element(concat(azurerm_network_ddos_protection_plan.ddos.*.id, [""]), 0) : null
+  value       = var.create_ddos_plan ? element(concat(azurerm_network_ddos_protection_plan.ddos[*].id, [""]), 0) : null
 }
 
 output "network_watcher_id" {
   description = "ID of Network Watcher"
-  value       = var.create_network_watcher != false ? element(concat(azurerm_network_watcher.nwatcher.*.id, [""]), 0) : null
+  value       = var.create_network_watcher != false ? element(concat(azurerm_network_watcher.nwatcher[*].id, [""]), 0) : null
 }
 
 output "hub_nsg_id" {
@@ -53,62 +53,62 @@ output "hub_default_subnet_name" {
 
 output "firewall_id" {
   description = "The ID of the Azure Firewall"
-  value       = azurerm_firewall.fw.0.id
+  value       = azurerm_firewall.fw[0].id
 }
 
 output "public_ip_prefix_id" {
   description = "The id of the Public IP Prefix resource"
-  value       = azurerm_public_ip_prefix.fw-pref.0.id
+  value       = azurerm_public_ip_prefix.fw-pref[0].id
 }
 
 output "firewall_public_ip" {
   description = "the public ip of firewall."
-  value       = azurerm_firewall.fw.0.ip_configuration.0.public_ip_address_id
+  value       = azurerm_firewall.fw[0].ip_configuration[0].public_ip_address_id
 }
 
 output "firewall_private_ip" {
   description = "The private ip of firewall."
-  value       = azurerm_firewall.fw.0.ip_configuration.0.private_ip_address
+  value       = azurerm_firewall.fw[0].ip_configuration[0].private_ip_address
 }
 
 output "firewall_name" {
   description = "The name of the Azure Firewall."
-  value       = azurerm_firewall.fw.0.name
+  value       = azurerm_firewall.fw[0].name
 }
 
 output "virtual_hub_private_ip_address" {
   description = "The private IP address associated with the Firewall"
-  value       = var.virtual_hub != null ? azurerm_firewall.fw.0.virtual_hub.0.private_ip_address : null
+  value       = var.virtual_hub != null ? azurerm_firewall.fw[0].virtual_hub[0].private_ip_address : null
 }
 
 output "virtual_hub_public_ip_addresses" {
   description = "The private IP address associated with the Firewall"
-  value       = var.virtual_hub != null ? azurerm_firewall.fw.0.virtual_hub.0.public_ip_addresses : null
+  value       = var.virtual_hub != null ? azurerm_firewall.fw[0].virtual_hub[0].public_ip_addresses : null
 }
 
 output "azure_bastion_subnet_id" {
   description = "The resource ID of Azure bastion subnet"
-  value       = var.enable_bastion_host ? element(concat([azurerm_subnet.abs_snet.0.id], [""]), 0) : null
+  value       = var.enable_bastion_host ? element(concat([azurerm_subnet.abs_snet[0].id], [""]), 0) : null
 }
 
 output "azure_bastion_public_ip" {
   description = "The public IP of the virtual network gateway"
-  value       = var.enable_bastion_host ? element(concat([azurerm_public_ip.bastion_pip.0.ip_address], [""]), 0) : null
+  value       = var.enable_bastion_host ? element(concat([azurerm_public_ip.bastion_pip[0].ip_address], [""]), 0) : null
 }
 
 output "azure_bastion_public_ip_fqdn" {
   description = "Fully qualified domain name of the virtual network gateway"
-  value       = var.enable_bastion_host ? element(concat([azurerm_public_ip.bastion_pip.0.fqdn], [""]), 0) : null
+  value       = var.enable_bastion_host ? element(concat([azurerm_public_ip.bastion_pip[0].fqdn], [""]), 0) : null
 }
 
 output "azure_bastion_host_id" {
   description = "The resource ID of the Bastion Host"
-  value       = var.enable_bastion_host ? azurerm_bastion_host.main.0.id : null
+  value       = var.enable_bastion_host ? azurerm_bastion_host.main[0].id : null
 }
 
 output "azure_bastion_host_fqdn" {
   description = "The fqdn of the Bastion Host"
-  value       = var.enable_bastion_host ? azurerm_bastion_host.main.0.dns_name : null
+  value       = var.enable_bastion_host ? azurerm_bastion_host.main[0].dns_name : null
 }
 
 output "privatelink_monitor_azure_com" {

--- a/modules/virtual-network-hub/private-dns.tf
+++ b/modules/virtual-network-hub/private-dns.tf
@@ -7,7 +7,7 @@ resource "azurerm_private_dns_zone" "privatelink_monitor_azure_com" {
     azurerm_virtual_network.hub_vnet
   ]
   name                = local.privateDnsZones_privatelink_monitor_azure_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
 }
 
 resource "azurerm_private_dns_zone" "privatelink_oms_opinsights_azure_com" {
@@ -15,7 +15,7 @@ resource "azurerm_private_dns_zone" "privatelink_oms_opinsights_azure_com" {
     azurerm_virtual_network.hub_vnet
   ]
   name                = local.privateDnsZones_privatelink_oms_opinsights_azure_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
 }
 
 resource "azurerm_private_dns_zone" "privatelink_ods_opinsights_azure_com" {
@@ -23,7 +23,7 @@ resource "azurerm_private_dns_zone" "privatelink_ods_opinsights_azure_com" {
     azurerm_virtual_network.hub_vnet
   ]
   name                = local.privateDnsZones_privatelink_ods_opinsights_azure_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
 }
 
 resource "azurerm_private_dns_zone" "privatelink_agentsvc_azure_automation_net" {
@@ -31,7 +31,7 @@ resource "azurerm_private_dns_zone" "privatelink_agentsvc_azure_automation_net" 
     azurerm_virtual_network.hub_vnet
   ]
   name                = local.privateDnsZones_privatelink_agentsvc_azure_automation_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
 }
 
 resource "azurerm_private_dns_zone" "privatelink_blob_core_cloudapi_net" {
@@ -39,7 +39,7 @@ resource "azurerm_private_dns_zone" "privatelink_blob_core_cloudapi_net" {
     azurerm_virtual_network.hub_vnet
   ]
   name                = local.privateDnsZones_privatelink_blob_core_cloudapi_net_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
 }
 
 # Link the DNS zones to the hub virtual network
@@ -49,7 +49,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "privatelink_monitor_az
     azurerm_private_dns_zone.privatelink_monitor_azure_com
   ]
   name                  = "${azurerm_virtual_network.hub_vnet.name}-${local.privateDnsZones_privatelink_monitor_azure_name}-link"
-  resource_group_name   = module.mod_hub_rg.0.resource_group_name
+  resource_group_name   = module.mod_hub_rg[0].resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.privatelink_monitor_azure_com.name
   virtual_network_id    = azurerm_virtual_network.hub_vnet.id
 }
@@ -60,7 +60,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "privatelink_oms_opinsi
     azurerm_private_dns_zone_virtual_network_link.privatelink_monitor_azure_com_privatelink_monitor_azure_com_link
   ]
   name                  = "${azurerm_virtual_network.hub_vnet.name}-${local.privateDnsZones_privatelink_oms_opinsights_azure_name}-link"
-  resource_group_name   = module.mod_hub_rg.0.resource_group_name
+  resource_group_name   = module.mod_hub_rg[0].resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.privatelink_oms_opinsights_azure_com.name
   virtual_network_id    = azurerm_virtual_network.hub_vnet.id
 }
@@ -71,7 +71,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "privatelink_ods_opinsi
     azurerm_private_dns_zone_virtual_network_link.privatelink_oms_opinsights_azure_com_privatelink_oms_opinsights_azure_com_link
   ]
   name                  = "${azurerm_virtual_network.hub_vnet.name}-${local.privateDnsZones_privatelink_ods_opinsights_azure_name}-link"
-  resource_group_name   = module.mod_hub_rg.0.resource_group_name
+  resource_group_name   = module.mod_hub_rg[0].resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.privatelink_ods_opinsights_azure_com.name
   virtual_network_id    = azurerm_virtual_network.hub_vnet.id
 }
@@ -82,7 +82,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "privatelink_agentsvc_a
     azurerm_private_dns_zone_virtual_network_link.privatelink_ods_opinsights_azure_com_privatelink_ods_opinsights_azure_com_link
   ]
   name                  = "${azurerm_virtual_network.hub_vnet.name}-${local.privateDnsZones_privatelink_agentsvc_azure_automation_name}-link"
-  resource_group_name   = module.mod_hub_rg.0.resource_group_name
+  resource_group_name   = module.mod_hub_rg[0].resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.privatelink_agentsvc_azure_automation_net.name
   virtual_network_id    = azurerm_virtual_network.hub_vnet.id
 }
@@ -93,7 +93,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "privateDnsZones_privat
     azurerm_private_dns_zone_virtual_network_link.privatelink_agentsvc_azure_automation_net_privatelink_agentsvc_azure_automation_net_link
   ]
   name                  = "${azurerm_virtual_network.hub_vnet.name}-${local.privateDnsZones_privatelink_blob_core_cloudapi_net_name}-link"
-  resource_group_name   = module.mod_hub_rg.0.resource_group_name
+  resource_group_name   = module.mod_hub_rg[0].resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.privatelink_blob_core_cloudapi_net.name
   virtual_network_id    = azurerm_virtual_network.hub_vnet.id
 }

--- a/modules/virtual-network-hub/route-table.tf
+++ b/modules/virtual-network-hub/route-table.tf
@@ -6,8 +6,8 @@ resource "azurerm_route_table" "routetable" {
     module.mod_hub_rg
   ]
   name                = local.hub_rt_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
-  location            = module.mod_hub_rg.0.resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
   # azurerm 4.x renamed `disable_bgp_route_propagation` to `bgp_route_propagation_enabled`
   # and inverted its semantics. Module variable kept for backward compatibility.
   bgp_route_propagation_enabled = !var.disable_bgp_route_propagation
@@ -21,10 +21,10 @@ resource "azurerm_subnet_route_table_association" "rtassoc" {
 
 resource "azurerm_route" "force_internet_tunneling" {
   name                   = "InternetForceTunneling"
-  resource_group_name    = module.mod_hub_rg.0.resource_group_name
+  resource_group_name    = module.mod_hub_rg[0].resource_group_name
   route_table_name       = azurerm_route_table.routetable.name
   address_prefix         = "0.0.0.0/0"
-  next_hop_in_ip_address = azurerm_firewall.fw.0.ip_configuration.0.private_ip_address
+  next_hop_in_ip_address = azurerm_firewall.fw[0].ip_configuration[0].private_ip_address
   next_hop_type          = "VirtualAppliance"
 
   count = var.enable_forced_tunneling ? 1 : 0
@@ -32,8 +32,8 @@ resource "azurerm_route" "force_internet_tunneling" {
 
 resource "azurerm_route" "route" {
   for_each               = var.route_table_routes
-  name                   = lower("route-to-firewall-${each.value.route_name}-${module.mod_hub_rg.0.resource_group_location}")
-  resource_group_name    = module.mod_hub_rg.0.resource_group_name
+  name                   = lower("route-to-firewall-${each.value.route_name}-${module.mod_hub_rg[0].resource_group_location}")
+  resource_group_name    = module.mod_hub_rg[0].resource_group_name
   route_table_name       = azurerm_route_table.routetable.name
   address_prefix         = each.value.address_prefix
   next_hop_type          = each.value.next_hop_type

--- a/modules/virtual-network-hub/scaffolding.tf
+++ b/modules/virtual-network-hub/scaffolding.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azregions" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_hub_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_hub_resource_group ? 1 : 0
 

--- a/modules/virtual-network-hub/storage-account.tf
+++ b/modules/virtual-network-hub/storage-account.tf
@@ -6,8 +6,8 @@
 #----------------------------------------------------------
 resource "azurerm_storage_account" "storeacc" {
   name                       = local.hub_sa_name
-  resource_group_name        = module.mod_hub_rg.0.resource_group_name
-  location                   = module.mod_hub_rg.0.resource_group_location
+  resource_group_name        = module.mod_hub_rg[0].resource_group_name
+  location                   = module.mod_hub_rg[0].resource_group_location
   account_kind               = "StorageV2"
   account_tier               = "Standard"
   account_replication_type   = "GRS"

--- a/modules/virtual-network-hub/subnet.tf
+++ b/modules/virtual-network-hub/subnet.tf
@@ -8,7 +8,7 @@
 resource "azurerm_subnet" "gw_snet" {
   count                = var.gateway_subnet_address_prefix != null ? 1 : 0
   name                 = "GatewaySubnet"
-  resource_group_name  = module.mod_hub_rg.0.resource_group_name
+  resource_group_name  = module.mod_hub_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.hub_vnet.name
   address_prefixes     = var.gateway_subnet_address_prefix
   service_endpoints    = var.gateway_service_endpoints
@@ -21,7 +21,7 @@ resource "azurerm_subnet" "gw_snet" {
 
 resource "azurerm_subnet" "default_snet" {
   name                                          = local.hub_snet_name
-  resource_group_name                           = module.mod_hub_rg.0.resource_group_name
+  resource_group_name                           = module.mod_hub_rg[0].resource_group_name
   virtual_network_name                          = azurerm_virtual_network.hub_vnet.name
   address_prefixes                              = var.hub_subnet_address_prefix
   service_endpoints                             = var.hub_subnet_service_endpoints
@@ -32,7 +32,7 @@ resource "azurerm_subnet" "default_snet" {
 resource "azurerm_subnet" "additional_snets" {
   for_each             = var.add_subnets
   name                 = lower(format("${var.org_name}-${module.mod_azregions.location_cli}-%s-snet", each.value.name))
-  resource_group_name  = module.mod_hub_rg.0.resource_group_name
+  resource_group_name  = module.mod_hub_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.hub_vnet.name
   address_prefixes     = each.value.address_prefixes
   service_endpoints    = lookup(each.value, "service_endpoints", [])

--- a/modules/virtual-network-hub/variables-bastion.tf
+++ b/modules/virtual-network-hub/variables-bastion.tf
@@ -2,66 +2,79 @@
 # Licensed under the MIT License.
 
 variable "enable_bastion_host" {
+  type        = bool
   description = "Enable Bastion Host"
   default     = false
 }
 
 variable "azure_bastion_public_ip_allocation_method" {
+  type        = string
   description = "Defines the allocation method for this IP address. Possible values are Static or Dynamic"
   default     = "Static"
 }
 
 variable "azure_bastion_public_ip_sku" {
+  type        = string
   description = "The SKU of the Public IP. Accepted values are Basic and Standard. Defaults to Basic"
   default     = "Standard"
 }
 
 variable "domain_name_label" {
+  type        = any
   description = "Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system"
   default     = null
 }
 
 variable "azure_bastion_service_name" {
+  type        = string
   description = "Specifies the name of the Bastion Host"
   default     = ""
 }
 
 variable "azure_bastion_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the Azure Bastion subnet"
   default     = []
 }
 
 variable "enable_copy_paste" {
+  type        = bool
   description = "Is Copy/Paste feature enabled for the Bastion Host?"
   default     = true
 }
 
 variable "enable_file_copy" {
+  type        = bool
   description = "Is File Copy feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }
 
 variable "azure_bastion_host_sku" {
+  type        = string
   description = "The SKU of the Bastion Host. Accepted values are `Basic` and `Standard`"
   default     = "Basic"
 }
 
 variable "enable_ip_connect" {
+  type        = bool
   description = "Is IP Connect feature enabled for the Bastion Host?"
   default     = false
 }
 
 variable "scale_units" {
+  type        = number
   description = "The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`."
   default     = 2
 }
 
 variable "enable_shareable_link" {
+  type        = bool
   description = "Is Shareable Link feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }
 
 variable "enable_tunneling" {
+  type        = bool
   description = "Is Tunneling feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }

--- a/modules/virtual-network-hub/variables-fw-policy.tf
+++ b/modules/virtual-network-hub/variables-fw-policy.tf
@@ -70,6 +70,7 @@ EOD
 
 
 variable "network_rule_collection" {
+  type        = any
   default     = {}
   description = <<EOD
     network_rule_collections = [
@@ -99,6 +100,7 @@ EOD
 }
 
 variable "nat_rule_collections" {
+  type        = any
   default     = {}
   description = <<EOD
     name     = nat_rule_collection1

--- a/modules/virtual-network-hub/variables-fw.tf
+++ b/modules/virtual-network-hub/variables-fw.tf
@@ -6,21 +6,25 @@
 ##############################
 
 variable "enable_firewall" {
+  type        = bool
   description = "Controls if Azure Firewall resources should be created for the Azure subscription"
   default     = true
 }
 
 variable "enable_forced_tunneling" {
+  type        = bool
   description = "Route all Internet-bound traffic to a designated next hop instead of going directly to the Internet"
   default     = true
 }
 
 variable "fw_client_snet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the Firewall subnet"
   default     = null
 }
 
 variable "fw_management_snet_address_prefix" {
+  type        = any
   description = "The address prefix to use for Firewall managemement subnet to enable forced tunnelling. The Management Subnet used for the Firewall must have the name `AzureFirewallManagementSubnet` and the subnet mask must be at least a `/26`."
   default     = null
 }
@@ -62,6 +66,7 @@ variable "fw_management_snet_private_link_service_network_policies_enabled" {
 }
 
 variable "fw_intrusion_detection_mode" {
+  type        = string
   description = "Controls if Azure Firewall Intrusion Detection System (IDS) should be enabled for the Azure subscription"
   default     = "Alert"
 
@@ -72,6 +77,7 @@ variable "fw_intrusion_detection_mode" {
 }
 
 variable "fw_threat_intelligence_mode" {
+  type        = string
   description = "Controls if Azure Firewall Threat Intelligence should be enabled for the Azure subscription"
   default     = "Alert"
 
@@ -82,6 +88,7 @@ variable "fw_threat_intelligence_mode" {
 }
 
 variable "base_policy_id" {
+  type        = any
   description = "The ID of the base policy to use for the Azure Firewall. This is used to create a new policy based on the base policy."
   default     = null
 }

--- a/modules/virtual-network-hub/variables-routetable.tf
+++ b/modules/virtual-network-hub/variables-routetable.tf
@@ -17,6 +17,7 @@ variable "route_table_routes" {
 }
 
 variable "disable_bgp_route_propagation" {
+  type        = bool
   description = "Whether to disable the default BGP route propagation on the subnet"
   default     = false
 }

--- a/modules/virtual-network-hub/variables-subnet.tf
+++ b/modules/virtual-network-hub/variables-subnet.tf
@@ -18,11 +18,13 @@ variable "hub_subnet_service_endpoints" {
 }
 
 variable "hub_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable network policies on the private endpoint subnet"
   default     = null
 }
 
 variable "hub_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable service endpoints on the private endpoint subnet"
   default     = null
 }
@@ -40,6 +42,7 @@ variable "add_subnets" {
 }
 
 variable "gateway_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the gateway subnet"
   default     = null
 }
@@ -51,11 +54,13 @@ variable "gateway_service_endpoints" {
 }
 
 variable "gateway_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable network policies on the private endpoint gateway subnet"
   default     = null
 }
 
 variable "gateway_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable link service network policies on the private link service gateway subnet"
   default     = null
 }

--- a/modules/virtual-network-hub/variables.tf
+++ b/modules/virtual-network-hub/variables.tf
@@ -68,26 +68,31 @@ variable "use_location_short_name" {
 ##########################
 
 variable "virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
 
 variable "create_ddos_plan" {
+  type        = bool
   description = "Create an ddos plan - Default is false"
   default     = false
 }
 
 variable "ddos_plan_name" {
+  type        = any
   description = "The name of AzureNetwork DDoS Protection Plan"
   default     = null
 }
 
 variable "dns_servers" {
+  type        = any
   description = "List of dns servers to use for virtual network"
   default     = []
 }
 
 variable "create_network_watcher" {
+  type        = bool
   description = "Controls if Network Watcher resources should be created for the Azure subscription"
   default     = false
 }

--- a/modules/virtual-network-hub/vnet.tf
+++ b/modules/virtual-network-hub/vnet.tf
@@ -16,8 +16,8 @@ resource "azurerm_virtual_network" "hub_vnet" {
     module.mod_hub_rg
   ]
   name                = local.hub_vnet_name
-  location            = module.mod_hub_rg.0.resource_group_location
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  location            = module.mod_hub_rg[0].resource_group_location
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   address_space       = var.virtual_network_address_space
   dns_servers         = var.dns_servers
   tags                = merge({ "ResourceName" = format("%s", local.hub_vnet_name) }, var.tags, )
@@ -39,7 +39,7 @@ resource "azurerm_virtual_network" "hub_vnet" {
 resource "azurerm_network_ddos_protection_plan" "ddos" {
   count               = var.create_ddos_plan ? 1 : 0
   name                = var.ddos_plan_name
-  resource_group_name = module.mod_hub_rg.0.resource_group_name
+  resource_group_name = module.mod_hub_rg[0].resource_group_name
   location            = var.location
   tags                = merge({ "ResourceName" = format("%s", var.ddos_plan_name) }, var.tags, )
 }
@@ -58,6 +58,6 @@ resource "azurerm_network_watcher" "nwatcher" {
   count               = var.create_network_watcher != false ? 1 : 0
   name                = "NetworkWatcher_${var.location}"
   location            = var.location
-  resource_group_name = azurerm_resource_group.nwatcher.0.name
+  resource_group_name = azurerm_resource_group.nwatcher[0].name
   tags                = merge({ "ResourceName" = format("%s", "NetworkWatcher_${var.location}") }, var.tags, )
 }

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -7,9 +7,9 @@ locals {
   name_suffix = lower(var.name_suffix)
 
   spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
-  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, "${data.popsrox_resource_name.snet.result}")
+  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, data.popsrox_resource_name.snet.result)
   spoke_snet_pe_name = data.popsrox_resource_name.snet.result
-  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, "${data.popsrox_resource_name.nsg.result}")
-  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, "${data.popsrox_resource_name.rt.result}")
+  spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, data.popsrox_resource_name.nsg.result)
+  spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, data.popsrox_resource_name.rt.result)
   spoke_sa_name      = coalesce(var.spoke_sa_custom_name, data.popsrox_resource_name.st.result)
 }

--- a/modules/virtual-network-spoke/nsg-custom-rules.tf
+++ b/modules/virtual-network-spoke/nsg-custom-rules.tf
@@ -5,7 +5,7 @@ resource "azurerm_network_security_rule" "nsg_rule" {
   for_each                    = { for index, v in var.nsg_additional_rules : v.name => v }
   name                        = each.value.name
   network_security_group_name = azurerm_network_security_group.nsg.name
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
 
   priority  = each.value.priority
   direction = coalesce(each.value.direction, "Inbound")

--- a/modules/virtual-network-spoke/nsg.tf
+++ b/modules/virtual-network-spoke/nsg.tf
@@ -3,8 +3,8 @@
 
 resource "azurerm_network_security_group" "nsg" {
   name                = local.spoke_nsg_name
-  location            = module.mod_spoke_rg.0.resource_group_location
-  resource_group_name = module.mod_spoke_rg.0.resource_group_name
+  location            = module.mod_spoke_rg[0].resource_group_location
+  resource_group_name = module.mod_spoke_rg[0].resource_group_name
   tags = merge(var.tags, {
     DeployedBy = format("AzureNoOpsTF [%s]", terraform.workspace)
   })
@@ -19,7 +19,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound" {
   for_each = toset(var.deny_all_inbound ? ["enabled"] : [])
 
   name                        = "deny-all-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Deny"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -35,7 +35,7 @@ resource "azurerm_network_security_rule" "http_inbound" {
   for_each = toset(var.http_inbound_allowed ? ["enabled"] : [])
 
   name                        = "http-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -52,7 +52,7 @@ resource "azurerm_network_security_rule" "https_inbound" {
   for_each = toset(var.https_inbound_allowed ? ["enabled"] : [])
 
   name                        = "https-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -69,7 +69,7 @@ resource "azurerm_network_security_rule" "ssh_inbound" {
   for_each = toset(var.ssh_inbound_allowed ? ["enabled"] : [])
 
   name                        = "ssh-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -86,7 +86,7 @@ resource "azurerm_network_security_rule" "rdp_inbound" {
   for_each = toset(var.rdp_inbound_allowed ? ["enabled"] : [])
 
   name                        = "rdp-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -103,7 +103,7 @@ resource "azurerm_network_security_rule" "winrm_inbound" {
   for_each = toset(var.winrm_inbound_allowed ? ["enabled"] : [])
 
   name                        = "winrm-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -120,7 +120,7 @@ resource "azurerm_network_security_rule" "appgw_health_probe_inbound" {
   for_each = toset(var.application_gateway_rules_enabled ? ["enabled"] : [])
 
   name                        = "appgw-health-probe-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -136,7 +136,7 @@ resource "azurerm_network_security_rule" "lb_health_probe_inbound" {
   for_each = toset(var.application_gateway_rules_enabled || var.load_balancer_rules_enabled ? ["enabled"] : [])
 
   name                        = "lb-health-probe-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -152,7 +152,7 @@ resource "azurerm_network_security_rule" "nfs_inbound" {
   for_each = toset(var.nfs_inbound_allowed ? ["enabled"] : [])
 
   name                        = "nfs-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name
@@ -169,7 +169,7 @@ resource "azurerm_network_security_rule" "cifs_inbound" {
   for_each = toset(var.cifs_inbound_allowed ? ["enabled"] : [])
 
   name                        = "cifs-inbound"
-  resource_group_name         = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name         = module.mod_spoke_rg[0].resource_group_name
   access                      = "Allow"
   direction                   = "Inbound"
   network_security_group_name = azurerm_network_security_group.nsg.name

--- a/modules/virtual-network-spoke/outputs.tf
+++ b/modules/virtual-network-spoke/outputs.tf
@@ -18,12 +18,12 @@ output "virtual_network_id" {
 
 output "virtual_network_address_space" {
   description = "List of address spaces that are used the virtual network."
-  value       = element(coalescelist(azurerm_virtual_network.spoke_vnet.*.address_space, [""]), 0)
+  value       = element(coalescelist(azurerm_virtual_network.spoke_vnet[*].address_space, [""]), 0)
 }
 
 output "network_watcher_id" {
   description = "ID of Network Watcher"
-  value       = var.is_spoke_deployed_to_same_hub_subscription == false ? element(concat(azurerm_network_watcher.nwatcher.*.id, [""]), 0) : null
+  value       = var.is_spoke_deployed_to_same_hub_subscription == false ? element(concat(azurerm_network_watcher.nwatcher[*].id, [""]), 0) : null
 }
 
 output "nsg_id" {

--- a/modules/virtual-network-spoke/peering.tf
+++ b/modules/virtual-network-spoke/peering.tf
@@ -6,7 +6,7 @@
 #-----------------------------------------------
 resource "azurerm_virtual_network_peering" "spoke_to_hub" {
   name                         = lower("peering-${azurerm_virtual_network.spoke_vnet.name}-to-${element(split("/", var.hub_virtual_network_id), 8)}")
-  resource_group_name          = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name          = module.mod_spoke_rg[0].resource_group_name
   virtual_network_name         = azurerm_virtual_network.spoke_vnet.name
   remote_virtual_network_id    = var.hub_virtual_network_id
   allow_virtual_network_access = var.allow_virtual_spoke_network_access

--- a/modules/virtual-network-spoke/routetable.tf
+++ b/modules/virtual-network-spoke/routetable.tf
@@ -6,8 +6,8 @@ resource "azurerm_route_table" "routetable" {
     module.mod_spoke_rg
   ]
   name                = local.spoke_rt_name
-  resource_group_name = module.mod_spoke_rg.0.resource_group_name
-  location            = module.mod_spoke_rg.0.resource_group_location
+  resource_group_name = module.mod_spoke_rg[0].resource_group_name
+  location            = module.mod_spoke_rg[0].resource_group_location
   # azurerm 4.x renamed `disable_bgp_route_propagation` to `bgp_route_propagation_enabled`
   # and inverted its semantics. Module variable kept for backward compatibility.
   bgp_route_propagation_enabled = !var.disable_bgp_route_propagation
@@ -27,7 +27,7 @@ resource "azurerm_subnet_route_table_association" "rtaddassoc" {
 
 resource "azurerm_route" "force_internet_tunneling" {
   name                   = "InternetForceTunneling"
-  resource_group_name    = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name    = module.mod_spoke_rg[0].resource_group_name
   route_table_name       = azurerm_route_table.routetable.name
   address_prefix         = "0.0.0.0/0"
   next_hop_in_ip_address = var.hub_firewall_private_ip_address
@@ -38,8 +38,8 @@ resource "azurerm_route" "force_internet_tunneling" {
 
 resource "azurerm_route" "route" {
   for_each               = var.route_table_routes
-  name                   = lower("route-to-firewall-${each.value.name}-${module.mod_spoke_rg.0.resource_group_location}")
-  resource_group_name    = module.mod_spoke_rg.0.resource_group_name
+  name                   = lower("route-to-firewall-${each.value.name}-${module.mod_spoke_rg[0].resource_group_location}")
+  resource_group_name    = module.mod_spoke_rg[0].resource_group_name
   route_table_name       = azurerm_route_table.routetable.name
   address_prefix         = each.value.address_prefix
   next_hop_type          = each.value.next_hop_type

--- a/modules/virtual-network-spoke/scaffolding.tf
+++ b/modules/virtual-network-spoke/scaffolding.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azregions" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_spoke_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_spoke_resource_group ? 1 : 0
 

--- a/modules/virtual-network-spoke/storage-account.tf
+++ b/modules/virtual-network-spoke/storage-account.tf
@@ -6,8 +6,8 @@
 #----------------------------------------------------------
 resource "azurerm_storage_account" "storeacc" {
   name                       = local.spoke_sa_name
-  resource_group_name        = module.mod_spoke_rg.0.resource_group_name
-  location                   = module.mod_spoke_rg.0.resource_group_location
+  resource_group_name        = module.mod_spoke_rg[0].resource_group_name
+  location                   = module.mod_spoke_rg[0].resource_group_location
   account_kind               = "StorageV2"
   account_tier               = "Standard"
   account_replication_type   = "GRS"

--- a/modules/virtual-network-spoke/subnet.tf
+++ b/modules/virtual-network-spoke/subnet.tf
@@ -7,7 +7,7 @@
 
 resource "azurerm_subnet" "default_snet" {
   name                 = local.spoke_snet_name
-  resource_group_name  = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name  = module.mod_spoke_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.spoke_vnet.name
   address_prefixes     = var.spoke_subnet_address_prefix
   service_endpoints    = var.spoke_subnet_service_endpoints
@@ -20,7 +20,7 @@ resource "azurerm_subnet" "default_snet" {
 resource "azurerm_subnet" "additional_snets" {
   for_each             = var.add_subnets
   name                 = lower(format("${var.org_name}-${module.mod_azregions.location_cli}-%s-snet", each.value.name))
-  resource_group_name  = module.mod_spoke_rg.0.resource_group_name
+  resource_group_name  = module.mod_spoke_rg[0].resource_group_name
   virtual_network_name = azurerm_virtual_network.spoke_vnet.name
   address_prefixes     = each.value.address_prefixes
   service_endpoints    = lookup(each.value, "service_endpoints", [])

--- a/modules/virtual-network-spoke/variables-routetable.tf
+++ b/modules/virtual-network-spoke/variables-routetable.tf
@@ -17,11 +17,13 @@ variable "route_table_routes" {
 }
 
 variable "disable_bgp_route_propagation" {
+  type        = bool
   description = "Whether to disable the default BGP route propagation on the subnet"
   default     = false
 }
 
 variable "enable_forced_tunneling_on_route_table" {
+  type        = bool
   description = "Route all Internet-bound traffic to a designated next hop instead of going directly to the Internet"
   default     = false
 }

--- a/modules/virtual-network-spoke/variables-subnet.tf
+++ b/modules/virtual-network-spoke/variables-subnet.tf
@@ -18,16 +18,19 @@ variable "spoke_subnet_service_endpoints" {
 }
 
 variable "spoke_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable network policies on the private endpoint subnet"
   default     = null
 }
 
 variable "spoke_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable service endpoints on the private endpoint subnet"
   default     = null
 }
 
 variable "add_subnets" {
+  type        = any
   description = "A list of subnets to add to the spoke"
   default     = {}
 }

--- a/modules/virtual-network-spoke/variables.tf
+++ b/modules/virtual-network-spoke/variables.tf
@@ -68,16 +68,19 @@ variable "use_location_short_name" {
 ##########################
 
 variable "virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
 
 variable "dns_servers" {
+  type        = any
   description = "List of dns servers to use for virtual network"
   default     = []
 }
 
 variable "is_spoke_deployed_to_same_hub_subscription" {
+  type        = bool
   description = "Indicates if the spoke is deployed to the same subscription as the hub. Default is true."
   default     = true
 }

--- a/modules/virtual-network-spoke/vnet.tf
+++ b/modules/virtual-network-spoke/vnet.tf
@@ -16,8 +16,8 @@ resource "azurerm_virtual_network" "spoke_vnet" {
     module.mod_spoke_rg
   ]
   name                = local.spoke_vnet_name
-  location            = module.mod_spoke_rg.0.resource_group_location
-  resource_group_name = module.mod_spoke_rg.0.resource_group_name
+  location            = module.mod_spoke_rg[0].resource_group_location
+  resource_group_name = module.mod_spoke_rg[0].resource_group_name
   address_space       = var.virtual_network_address_space
   dns_servers         = var.dns_servers
   tags                = merge({ "ResourceName" = format("%s", local.spoke_vnet_name) }, var.tags, )
@@ -42,6 +42,6 @@ resource "azurerm_network_watcher" "nwatcher" {
   count               = var.is_spoke_deployed_to_same_hub_subscription == false ? 1 : 0
   name                = "NetworkWatcher_${var.location}"
   location            = var.location
-  resource_group_name = azurerm_resource_group.nwatcher.0.name
+  resource_group_name = azurerm_resource_group.nwatcher[0].name
   tags                = merge({ "ResourceName" = format("%s", "NetworkWatcher_${var.location}") }, var.tags, )
 }

--- a/tests/fixtures/main.tf
+++ b/tests/fixtures/main.tf
@@ -136,7 +136,7 @@ module "hub_spoke_landing_zone" {
         {
           name                  = "AllSpokeTraffic"
           protocols             = ["Any"]
-          source_addresses      = ["${var.firewall_supernet_IP_address}"]
+          source_addresses      = [var.firewall_supernet_IP_address]
           destination_addresses = ["*"]
           destination_ports     = ["*"]
         }

--- a/varables-id-spoke.tf
+++ b/varables-id-spoke.tf
@@ -40,6 +40,7 @@ variable "id_subscription_id" {
 }
 
 variable "is_id_deployed_to_same_hub_subscription" {
+  type        = bool
   description = "Indicates if the id is deployed to the same subscription as the hub. Default is true."
   default     = true
 }
@@ -49,11 +50,13 @@ variable "is_id_deployed_to_same_hub_subscription" {
 ##########################
 
 variable "custom_id_vnet_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the vnet for the id vnet. If not specified, the default naming is used"
   default     = null
 }
 
 variable "id_virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
@@ -63,21 +66,25 @@ variable "id_virtual_network_address_space" {
 ##########################
 
 variable "id_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the subnet"
   default     = null
 }
 
 variable "id_subnet_service_endpoints" {
+  type        = any
   description = "Service endpoints to add to the subnet"
   default     = null
 }
 
 variable "id_subnet_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private endpoint network policies on the subnet"
   default     = null
 }
 
 variable "id_subnet_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private link service network policies on the subnet"
   default     = null
 }
@@ -99,6 +106,7 @@ variable "id_additional_subnets" {
 ##############################
 
 variable "id_routetable_custom_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the route table. If not specified, the default naming is used"
   default     = null
 }

--- a/varables-ops-spoke.tf
+++ b/varables-ops-spoke.tf
@@ -23,6 +23,7 @@ variable "ops_subscription_id" {
 }
 
 variable "is_ops_deployed_to_same_hub_subscription" {
+  type        = bool
   description = "Indicates if the ops is deployed to the same subscription as the hub. Default is true."
   default     = true
 }
@@ -32,6 +33,7 @@ variable "is_ops_deployed_to_same_hub_subscription" {
 ##########################
 
 variable "ops_virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
@@ -41,21 +43,25 @@ variable "ops_virtual_network_address_space" {
 ##########################
 
 variable "ops_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the subnet"
   default     = null
 }
 
 variable "ops_subnet_service_endpoints" {
+  type        = any
   description = "Service endpoints to add to the subnet"
   default     = null
 }
 
 variable "ops_subnet_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private endpoint network policies on the subnet"
   default     = null
 }
 
 variable "ops_subnet_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private link service network policies on the subnet"
   default     = null
 }
@@ -77,6 +83,7 @@ variable "ops_additional_subnets" {
 ##############################
 
 variable "ops_routetable_custom_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the route table. If not specified, the default naming is used"
   default     = null
 }

--- a/varables-svcs-spoke.tf
+++ b/varables-svcs-spoke.tf
@@ -40,6 +40,7 @@ variable "svcs_subscription_id" {
 }
 
 variable "is_svcs_deployed_to_same_hub_subscription" {
+  type        = bool
   description = "Indicates if the svcs is deployed to the same subscription as the hub. Default is true."
   default     = true
 }
@@ -49,11 +50,13 @@ variable "is_svcs_deployed_to_same_hub_subscription" {
 ##########################
 
 variable "custom_svcs_vnet_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the vnet for the svcs vnet. If not specified, the default naming is used"
   default     = null
 }
 
 variable "svcs_virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
@@ -63,21 +66,25 @@ variable "svcs_virtual_network_address_space" {
 ##########################
 
 variable "svcs_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the subnet"
   default     = null
 }
 
 variable "svcs_subnet_service_endpoints" {
+  type        = any
   description = "Service endpoints to add to the subnet"
   default     = null
 }
 
 variable "svcs_subnet_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private endpoint network policies on the subnet"
   default     = null
 }
 
 variable "svcs_subnet_private_link_service_network_policies_enabled" {
+  type        = any
   description = "Enable or disable private link service network policies on the subnet"
   default     = null
 }
@@ -99,6 +106,7 @@ variable "svcs_additional_subnets" {
 ##############################
 
 variable "svcs_routetable_custom_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the route table. If not specified, the default naming is used"
   default     = null
 }

--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -2,61 +2,73 @@
 # Licensed under the MIT License.
 
 variable "enable_bastion_host" {
+  type        = bool
   description = "Enable Bastion Host"
   default     = false
 }
 
 variable "azure_bastion_public_ip_allocation_method" {
+  type        = string
   description = "Defines the allocation method for this IP address. Possible values are Static or Dynamic"
   default     = "Static"
 }
 
 variable "azure_bastion_public_ip_sku" {
+  type        = string
   description = "The SKU of the Public IP. Accepted values are Basic and Standard. Defaults to Basic"
   default     = "Standard"
 }
 
 variable "domain_name_label" {
+  type        = any
   description = "Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system"
   default     = null
 }
 
 variable "azure_bastion_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the Azure Bastion subnet"
   default     = []
 }
 
 variable "enable_copy_paste" {
+  type        = bool
   description = "Is Copy/Paste feature enabled for the Bastion Host?"
   default     = true
 }
 
 variable "enable_file_copy" {
+  type        = bool
   description = "Is File Copy feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }
 
 variable "azure_bastion_host_sku" {
+  type        = string
   description = "The SKU of the Bastion Host. Accepted values are `Basic` and `Standard`"
   default     = "Basic"
 }
 
 variable "enable_ip_connect" {
+  type        = bool
   description = "Is IP Connect feature enabled for the Bastion Host?"
   default     = false
 }
 
 variable "scale_units" {
+  type        = number
   description = "The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. `scale_units` only can be changed when `sku` is `Standard`. `scale_units` is always `2` when `sku` is `Basic`."
   default     = 2
 }
 
 variable "enable_shareable_link" {
+  type        = bool
   description = "Is Shareable Link feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }
 
 variable "enable_tunneling" {
+  type        = bool
   description = "Is Tunneling feature enabled for the Bastion Host. Only supported whne `sku` is `Standard`"
   default     = false
 }

--- a/variables-hub.tf
+++ b/variables-hub.tf
@@ -40,16 +40,19 @@ variable "hub_vnet_address_space" {
 }
 
 variable "create_ddos_plan" {
+  type        = bool
   description = "Create an ddos plan - Default is false"
   default     = false
 }
 
 variable "ddos_plan_name" {
+  type        = any
   description = "The name of AzureNetwork DDoS Protection Plan"
   default     = null
 }
 
 variable "create_network_watcher" {
+  type        = bool
   description = "Controls if Network Watcher resources should be created for the Azure subscription"
   default     = false
 }
@@ -71,11 +74,13 @@ variable "hub_subnet_service_endpoints" {
 }
 
 variable "hub_private_endpoint_network_policies_enabled" {
+  type        = any
   description = "Whether or not to enable network policies on the private endpoint subnet"
   default     = null
 }
 
 variable "hub_private_endpoint_service_endpoints_enabled" {
+  type        = any
   description = "Whether or not to enable service endpoints on the private endpoint subnet"
   default     = null
 }
@@ -93,6 +98,7 @@ variable "hub_add_subnets" {
 }
 
 variable "gateway_subnet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the gateway subnet"
   default     = null
 }
@@ -104,6 +110,7 @@ variable "gateway_service_endpoints" {
 }
 
 variable "dns_servers" {
+  type        = any
   description = "List of dns servers to use for virtual network"
   default     = []
 }
@@ -113,19 +120,23 @@ variable "dns_servers" {
 ##############################
 
 variable "enable_firewall" {
+  type        = any
   description = "Controls if Azure Firewall resources should be created for the Azure subscription"
 }
 
 variable "enable_forced_tunneling" {
+  type        = any
   description = "Route all Internet-bound traffic to a designated next hop instead of going directly to the Internet"
 }
 
 variable "fw_client_snet_address_prefix" {
+  type        = any
   description = "The address prefix to use for the Firewall subnet"
   default     = null
 }
 
 variable "fw_management_snet_address_prefix" {
+  type        = any
   description = "The address prefix to use for Firewall managemement subnet to enable forced tunnelling. The Management Subnet used for the Firewall must have the name `AzureFirewallManagementSubnet` and the subnet mask must be at least a `/26`."
   default     = null
 }
@@ -167,11 +178,13 @@ variable "fw_management_snet_private_link_service_network_policies_enabled" {
 }
 
 variable "fw_sku" {
+  type        = any
   description = "The SKU of the Azure Firewall"
   default     = null
 }
 
 variable "fw_tier" {
+  type        = any
   description = "The Tier of the Azure Firewall"
   default     = null
 }
@@ -195,6 +208,7 @@ variable "fw_dns_servers" {
 }
 
 variable "fw_intrusion_detection_mode" {
+  type        = string
   description = "Controls if Azure Firewall Intrusion Detection System (IDS) should be enabled for the Azure subscription"
   default     = "Alert"
 
@@ -205,6 +219,7 @@ variable "fw_intrusion_detection_mode" {
 }
 
 variable "fw_threat_intelligence_mode" {
+  type        = string
   description = "Controls if Azure Firewall Threat Intelligence should be enabled for the Azure subscription"
   default     = "Alert"
 
@@ -215,6 +230,7 @@ variable "fw_threat_intelligence_mode" {
 }
 
 variable "base_policy_id" {
+  type        = any
   description = "The ID of the base policy to use for the Azure Firewall. This is used to create a new policy based on the base policy."
   default     = null
 }
@@ -345,6 +361,7 @@ EOD
 
 
 variable "fw_policy_network_rule_collection" {
+  type = any
   default = [
     {
       name     = "AllowAzureCloud"
@@ -403,6 +420,7 @@ EOD
 }
 
 variable "fw_policy_nat_rule_collections" {
+  type        = any
   default     = {}
   description = <<EOD
     name     = nat_rule_collection1
@@ -629,6 +647,7 @@ variable "hub_allowed_cifs_source" {
 ##################################
 
 variable "security_center_subscription_pricing" {
+  type        = string
   description = "The pricing tier to use. Possible values are Free and Standard"
   default     = "Standard"
 }
@@ -640,21 +659,25 @@ variable "security_center_contacts" {
 }
 
 variable "scope_resource_id" {
+  type        = any
   description = "The scope of VMs to send their security data to the desired workspace, unless overridden by a setting with more specific scope"
   default     = null
 }
 
 variable "security_center_setting_name" {
+  type        = string
   description = "The setting to manage. Possible values are `MCAS` and `WDAT`"
   default     = "MCAS"
 }
 
 variable "enable_security_center_setting" {
+  type        = bool
   description = "Boolean flag to enable/disable data access"
   default     = false
 }
 
 variable "enable_security_center_auto_provisioning" {
+  type        = string
   description = "Should the security agent be automatically provisioned on Virtual Machines in this subscription?"
   default     = "Off"
 }

--- a/variables-naming.tf
+++ b/variables-naming.tf
@@ -96,6 +96,7 @@ variable "ops_logging_sa_custom_name" {
 
 # Custom Ops Logging naming override
 variable "custom_ops_vnet_name" {
+  type        = any
   description = "(Optional) Specifies the custom name of the vnet for the ops vnet. If not specified, the default naming is used"
   default     = null
 }

--- a/variables.provider.tf
+++ b/variables.provider.tf
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 variable "provider_azurerm_features_keyvault" {
+  type = any
   default = {
     permanently_delete_on_destroy              = true
     purge_soft_delete_on_destroy               = true
@@ -16,12 +17,14 @@ variable "provider_azurerm_features_keyvault" {
 }
 
 variable "provider_azurerm_features_log_analytics_workspace" {
+  type = any
   default = {
     permanently_delete_on_destroy = true
   }
 }
 
 variable "provider_azurerm_features_virtual_machine" {
+  type = any
   default = {
     delete_os_disk_on_deletion     = true
     graceful_shutdown              = false
@@ -30,6 +33,7 @@ variable "provider_azurerm_features_virtual_machine" {
 }
 
 variable "provider_azurerm_features_resource_group" {
+  type = any
   default = {
     prevent_deletion_if_contains_resources = true
   }


### PR DESCRIPTION
## Phase 4b — Mechanical tflint fixes

This PR applies automated mechanical fixes for ~4 tflint rule categories.
Closes part of #10.

### Violation reduction

| Metric | Count |
| --- | ---: |
| Before | 383 |
| After  | 126 |
| Reduction | 257 (67%) |

> "Before" is measured against the Phase 4 `.tflint.hcl` template
> (`.phase4-scratch/tflint.hcl` in the umbrella repo), applied locally for
> measurement only. This PR does **not** modify `.tflint.hcl` — that is
> handled by the parallel `chore/tflint-rules-enabled` PR (Phase 4) once
> the count drops below the 50-violation threshold.

### Fixes applied
- `terraform_deprecated_index`: `x.0.id` → `x[0].id`
- `terraform_typed_variables`: added `type = any` (or inferred type) to variable blocks missing a type
- `terraform_module_pinned_source`: pinned `github.com/POps-Rox/terraform-az(-entra)?-overlays-*` sources to `?ref=v2.0.0`
- `terraform_deprecated_interpolation`: `"${x}"` → `x`

### Left for manual follow-up
- `terraform_unused_declarations` — case-by-case review (some may be intentional public surface).
- `terraform_deprecated_lookup` — too risky to auto-rewrite `lookup(map, key)` → `map["key"]`.

### Validation
- `terraform fmt -recursive` — clean
- `terraform validate` — passes (when `terraform init -backend=false -upgrade` succeeds)

cc @JoshLuedeman
