### PR TITLE
chore: classify and clean up unused declarations

### DIFF
--- a/examples/multi-with-orchestration-w-wl-spoke/variables.provider.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/variables.provider.tf
@@ -1,5 +1,9 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: provider-feature defaults for the (not-yet-wired) workload-spoke
+# azurerm.wl provider. Wire-up tracked in issue #12.
 
 variable "provider_azurerm_features_keyvault" {
   type = any

--- a/examples/multi-with-orchestration-w-wl-spoke/versions.tf
+++ b/examples/multi-with-orchestration-w-wl-spoke/versions.tf
@@ -118,6 +118,7 @@ provider "azurerm" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # WIP: workload-spoke azurerm.wl provider not yet wired into any module call. See issue #12.
 provider "azurerm" {
   alias           = "wl"
   environment     = "usgovernment"

--- a/modules/operational-logging/locals.tf
+++ b/modules/operational-logging/locals.tf
@@ -13,14 +13,6 @@ resource "random_id" "uniqueString" {
   byte_length = 8
 }
 
-# The following block of locals are used to avoid using
-# empty object types in the code.
-locals {
-  empty_string = ""
-  empty_list   = []
-  empty_map    = {}
-}
-
 # Convert the input vars to locals, applying any required
 # logic needed before they are used in the module.
 # No vars should be referenced elsewhere in the module.

--- a/modules/operational-logging/scaffolding.tf
+++ b/modules/operational-logging/scaffolding.tf
@@ -13,6 +13,7 @@ module "mod_azregions" {
 #---------------------------------------------------------
 # Resource Group Creation
 #----------------------------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIP: "use existing RG" path not wired downstream. See issue #12.
 data "azurerm_resource_group" "logging_rgrp" {
   count = var.create_logging_resource_group == false ? 1 : 0
   name  = var.custom_logging_resource_group_name

--- a/modules/operational-logging/varaibles-defender.tf
+++ b/modules/operational-logging/varaibles-defender.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: filename is misspelled (varaibles -> variables) and some declared
+# variables are not wired into the module body. Rename + wire-up tracked in
+# issue #12 (subset of umbrella issue #10).
 
 variable "security_center_subscription_pricing" {
   type        = string

--- a/modules/operational-logging/varaibles-logging.tf
+++ b/modules/operational-logging/varaibles-logging.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: filename is misspelled (varaibles -> variables) and some declared
+# variables are not wired into the module body. Rename + wire-up tracked in
+# issue #12 (subset of umbrella issue #10).
 
 ###########################
 # Logging Configuration  ##

--- a/modules/operational-logging/variables.tf
+++ b/modules/operational-logging/variables.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 
 ###########################

--- a/modules/virtual-network-hub/locals-tags.tf
+++ b/modules/virtual-network-hub/locals-tags.tf
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------
 
 locals {
+  # tflint-ignore: terraform_unused_declarations  # WIP: see issue #12 — not yet merged into module tags.
   default_tags = var.default_tags_enabled ? {
     env      = var.deploy_environment
     workload = var.workload_name

--- a/modules/virtual-network-hub/scaffolding.tf
+++ b/modules/virtual-network-hub/scaffolding.tf
@@ -13,6 +13,7 @@ module "mod_azregions" {
 #---------------------------------------------------------
 # Resource Group Creation
 #----------------------------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIP: "use existing RG" path not wired downstream. See issue #12.
 data "azurerm_resource_group" "rgrp" {
   count = var.create_hub_resource_group == false ? 1 : 0
   name  = var.custom_resource_group_name

--- a/modules/virtual-network-hub/variables-fw.tf
+++ b/modules/virtual-network-hub/variables-fw.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 ##############################
 # Firewall Configuration    ##

--- a/modules/virtual-network-hub/variables-naming.tf
+++ b/modules/virtual-network-hub/variables-naming.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 # Generic naming variables
 variable "name_prefix" {

--- a/modules/virtual-network-hub/variables-tags.tf
+++ b/modules/virtual-network-hub/variables-tags.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "default_tags_enabled" {
   description = "Option to enable or disable default tags"

--- a/modules/virtual-network-hub/variables.tf
+++ b/modules/virtual-network-hub/variables.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 
 ###########################

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -8,6 +8,7 @@ locals {
 
   spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
   spoke_snet_name    = coalesce(var.spoke_snet_custom_name, data.popsrox_resource_name.snet.result)
+  # tflint-ignore: terraform_unused_declarations  # WIP: see issue #12 — private-endpoint subnet name not wired in.
   spoke_snet_pe_name = data.popsrox_resource_name.snet.result
   spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, data.popsrox_resource_name.nsg.result)
   spoke_rt_name      = coalesce(var.spoke_routtable_custom_name, data.popsrox_resource_name.rt.result)

--- a/modules/virtual-network-spoke/locals-naming.tf
+++ b/modules/virtual-network-spoke/locals-naming.tf
@@ -6,8 +6,8 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  spoke_vnet_name    = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
-  spoke_snet_name    = coalesce(var.spoke_snet_custom_name, data.popsrox_resource_name.snet.result)
+  spoke_vnet_name = coalesce(var.spoke_vnet_custom_name, data.popsrox_resource_name.vnet.result)
+  spoke_snet_name = coalesce(var.spoke_snet_custom_name, data.popsrox_resource_name.snet.result)
   # tflint-ignore: terraform_unused_declarations  # WIP: see issue #12 — private-endpoint subnet name not wired in.
   spoke_snet_pe_name = data.popsrox_resource_name.snet.result
   spoke_nsg_name     = coalesce(var.spoke_nsg_custom_name, data.popsrox_resource_name.nsg.result)

--- a/modules/virtual-network-spoke/locals-tags.tf
+++ b/modules/virtual-network-spoke/locals-tags.tf
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------
 
 locals {
+  # tflint-ignore: terraform_unused_declarations  # WIP: see issue #12 — not yet merged into module tags.
   default_tags = var.default_tags_enabled ? {
     env      = var.deploy_environment
     workload = var.workload_name

--- a/modules/virtual-network-spoke/scaffolding.tf
+++ b/modules/virtual-network-spoke/scaffolding.tf
@@ -13,6 +13,7 @@ module "mod_azregions" {
 #---------------------------------------------------------
 # Resource Group Creation
 #----------------------------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIP: "use existing RG" path not wired downstream. See issue #12.
 data "azurerm_resource_group" "rgrp" {
   count = var.create_spoke_resource_group == false ? 1 : 0
   name  = var.custom_resource_group_name

--- a/modules/virtual-network-spoke/variables-naming.tf
+++ b/modules/virtual-network-spoke/variables-naming.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 # Generic naming variables
 variable "name_prefix" {

--- a/modules/virtual-network-spoke/variables-peerings.tf
+++ b/modules/virtual-network-spoke/variables-peerings.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "hub_virtual_network_id" {
   description = "The ID of the hub virtual network to peer with the spoke virtual network."

--- a/modules/virtual-network-spoke/variables-tags.tf
+++ b/modules/virtual-network-spoke/variables-tags.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "default_tags_enabled" {
   description = "Option to enable or disable default tags"

--- a/modules/virtual-network-spoke/variables.tf
+++ b/modules/virtual-network-spoke/variables.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 
 ###########################

--- a/modules/virtual-network-spoke/vnet.tf
+++ b/modules/virtual-network-spoke/vnet.tf
@@ -26,6 +26,7 @@ resource "azurerm_virtual_network" "spoke_vnet" {
 #-------------------------------------
 # Network Watcher - Default is "true"
 #-------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIP: NetworkWatcherRG lookup not yet referenced by downstream resources. See issue #12.
 data "azurerm_resource_group" "netwatch" {
   count = var.is_spoke_deployed_to_same_hub_subscription == true ? 1 : 0
   name  = "NetworkWatcherRG"

--- a/varables-id-spoke.tf
+++ b/varables-id-spoke.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 
 ########################

--- a/varables-ops-spoke.tf
+++ b/varables-ops-spoke.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 #################################
 # Ops Spoke Configuration     ###

--- a/varables-svcs-spoke.tf
+++ b/varables-svcs-spoke.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 
 ########################

--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "enable_bastion_host" {
   type        = bool

--- a/variables-hub.tf
+++ b/variables-hub.tf
@@ -1,5 +1,11 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: This file declares the root module's public input surface.
+# Several variables are accepted for forward/backward compatibility and are
+# not all wired into the current implementation. Tracked separately under
+# issue #10 (Phase 4 tflint remediation).
 
 
 ##########################

--- a/variables-naming.tf
+++ b/variables-naming.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 # Generic naming variables
 variable "name_prefix" {

--- a/variables-peerings.tf
+++ b/variables-peerings.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 ###################
 # Spoke peering  ##

--- a/variables-tags.tf
+++ b/variables-tags.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "default_tags_enabled" {
   description = "Option to enable or disable default tags"

--- a/variables.provider.tf
+++ b/variables.provider.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 variable "provider_azurerm_features_keyvault" {
   type = any

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,10 @@
+# tflint-ignore-file: terraform_unused_declarations
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+#
+# Rationale: declared module input surface; several vars are forward-/backward-compat
+# placeholders or are tracked as deferred wire-up. See umbrella issue #10 and the
+# specific WIP follow-ups in issue #12.
 
 ###########################
 # Global Configuration   ##


### PR DESCRIPTION
## Summary

Address 115 `terraform_unused_declarations` findings (in non-`_wip/` paths)
using the A / B / C classification from #10.

| Category | Count | Action |
| --- | ---: | --- |
| A — truly dead | 3 | Delete |
| B — public-API surface | 99 | `# tflint-ignore-file: terraform_unused_declarations` with rationale linking to #10 |
| C — WIP / planned feature | 13 | Annotated; tracked in new issue #12 |
| **Total** | **115** | — |

## Highlights

**A (delete).** `modules/operational-logging/locals.tf` declared
`empty_string`, `empty_list`, `empty_map` but the only call sites were
inside a `/* ... */` commented-out `locals` block — truly dead.

**B (annotate).** Module/root variable files declare a wide input surface
for downstream consumers; most vars are accepted for compat or are
forwarded conditionally. Used file-level `tflint-ignore-file` to avoid
inline-comment noise on every block. Each annotated file points back to
#10 and #12 in its rationale.

**C (annotate + issue #12).** A small set of findings looked like deferred
wire-up rather than dead code. They were annotated with inline
`# tflint-ignore: terraform_unused_declarations` comments (or file-level
ignores for the typo'd `varaibles-*.tf` files) and tracked under #12.
Highlights:

- `modules/operational-logging/varaibles-defender.tf` /
  `varaibles-logging.tf` — typo'd filenames (`varaibles` → `variables`).
  The files **are** used (`enable_sentinel`, `log_analytics_workspace_sku`,
  `log_analytics_logs_retention_in_days`, `create_logging_resource_group`
  are all referenced by the module body), so the files are not abandoned —
  but the remaining vars in them are not wired in. Recommended a rename +
  wire-up in #12. Not removed.
- `modules/virtual-network-hub/variables-fw.tf` — `fw_application_rules`,
  `fw_network_rules`, `fw_nat_rules` are consumed via `local.fw_*_rules`
  in `firewall.tf`, but those locals are **never defined**. The root
  module forwards user input into the variables; the var → local transform
  is the missing piece.
- "Use existing RG" data sources in all three modules' `scaffolding.tf` —
  declared under `count = create_*_resource_group == false ? 1 : 0` but
  never referenced downstream, so passing `create_*_resource_group = false`
  silently produces a broken deployment.
- `examples/multi-with-orchestration-w-wl-spoke` — `azurerm.wl` provider
  alias and its two feature-default vars are declared but no module call
  references `providers = { azurerm = azurerm.wl }`. The example name ends
  in `-w-wl-spoke` so the intent is clearly to wire a workload spoke.

## Verification

```text
$ tflint --recursive -f compact 2>&1 | grep terraform_unused_declarations | grep -v _wip/
(no output)
```

Before: 115. After: 0.

`terraform validate` still succeeds for `modules/operational-logging`
after the locals deletion.

## Scope notes

- Only `terraform_unused_declarations` was addressed. Pre-existing findings
  for `terraform_deprecated_lookup`, `terraform_required_providers`,
  `terraform_required_version`, and `terraform_typed_variables` (9 total,
  outside `_wip/`) are unchanged.
- `_wip/` is excluded from CI lint per #11 (Phase 4b) and was not modified.

Closes (partial) #10. See follow-up #12.
